### PR TITLE
Support for unc paths

### DIFF
--- a/src/main/java/org/jvnet/winp/Native.java
+++ b/src/main/java/org/jvnet/winp/Native.java
@@ -69,8 +69,8 @@ class Native {
 
                 if(filePortion.startsWith("file:/")) {
                     filePortion = filePortion.substring(6);
-                    if(filePortion.startsWith("//"))
-                        filePortion = filePortion.substring(2);
+                    if(filePortion.startsWith("/"))
+                        filePortion = "/"+filePortion;
                     filePortion = URLDecoder.decode(filePortion);
                     String preferred = System.getProperty(DLL_TARGET);
                     File jarFile = new File(preferred != null ? preferred : filePortion);


### PR DESCRIPTION
With this fix it works only if the dll is already extracted from the jar.

It's strange, even with write permissions (Everyone have total control in windows security options) on the location dir of the winp.jar, the dll file can't be written.

java.io.FileNotFoundException: \Optimus\Winp\target\winp.dll (Acces Denied)
        at java.io.FileOutputStream.open(Native Method)
        at java.io.FileOutputStream.<init>(Unknown Source)
