### PR TITLE
Issue 6: Fix recursive process killing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+Debug
+Release
+ipch
+x64
+*.filters
+*.ncb
+*.opensdf
+*.sdf
+*.suo
+*.user

--- a/envvar-cmdline.cpp
+++ b/envvar-cmdline.cpp
@@ -48,74 +48,79 @@ JNIEXPORT jstring JNICALL Java_org_jvnet_winp_Native_getCmdLineAndEnvVars(
 	// see http://msdn2.microsoft.com/en-us/library/ms674678%28VS.85%29.aspx
 	// for kernel string functions
 
-	auto_handle hProcess = ::OpenProcess(PROCESS_QUERY_INFORMATION|PROCESS_VM_READ,FALSE,pid);
-	if(hProcess==NULL) {
-		reportError(pEnv,"Failed to open process");
+	auto_handle hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
+	if(!hProcess) {
+		reportError(pEnv, "Failed to open process");
 		return NULL;
 	}
 
 	// obtain PROCESS_BASIC_INFORMATION
 	PROCESS_BASIC_INFORMATION ProcInfo;
-	SIZE_T _;
-	if(!NT_SUCCESS(ZwQueryInformationProcess(hProcess, ProcessBasicInformation, &ProcInfo, sizeof(ProcInfo), &_))) {
-		reportError(pEnv,"Failed to ZWQueryInformationProcess");
+	SIZE_T sRead;
+	if(!NT_SUCCESS(ZwQueryInformationProcess(hProcess, ProcessBasicInformation, &ProcInfo, sizeof(ProcInfo), &sRead))) {
+		reportError(pEnv, "Failed to ZWQueryInformationProcess");
 		return NULL;
 	}
 
 	// from there to PEB
 	PEB ProcPEB;
-	if(!ReadProcessMemory(hProcess, ProcInfo.PebBaseAddress, &ProcPEB, sizeof(ProcPEB), &_)) {
-		reportError(pEnv,"Failed to read PEB");
+	if(!ReadProcessMemory(hProcess, ProcInfo.PebBaseAddress, &ProcPEB, sizeof(ProcPEB), &sRead)) {
+		reportError(pEnv, "Failed to read PEB");
 		return NULL;
 	}
 
 	// then to INFOBLOCK
 	RTL_USER_PROCESS_PARAMETERS ProcBlock;
-	if(!ReadProcessMemory(hProcess, ProcPEB.dwInfoBlockAddress, &ProcBlock, sizeof(ProcBlock), &_)) {
-		reportError(pEnv,"Failed to read RT_USER_PROCESS_PARAMETERS");
+	if(!ReadProcessMemory(hProcess, ProcPEB.dwInfoBlockAddress, &ProcBlock, sizeof(ProcBlock), &sRead)) {
+		reportError(pEnv, "Failed to read RT_USER_PROCESS_PARAMETERS");
 		return NULL;
 	}
 
 	// now read command line aguments
-	auto_localmem<LPWSTR> pszCmdLine = ::LocalAlloc(LMEM_FIXED|LMEM_ZEROINIT,ProcBlock.wLength+2);
-	if(pszCmdLine==NULL) {
-		reportError(pEnv,"Failed to allocate memory for reading command line");
+	auto_localmem<LPWSTR> pszCmdLine = LocalAlloc(LMEM_FIXED | LMEM_ZEROINIT, ProcBlock.wLength + 2);
+	if(!pszCmdLine) {
+		reportError(pEnv, "Failed to allocate memory for reading command line");
 		return NULL;
 	}
 
-	if(!ReadProcessMemory(hProcess, ProcBlock.dwCmdLineAddress, pszCmdLine, ProcBlock.wLength, &_)) {
+	if(!ReadProcessMemory(hProcess, ProcBlock.dwCmdLineAddress, pszCmdLine, ProcBlock.wLength, &sRead)) {
 		// on some processes, I noticed that the value of dwCmdLineAddress doesn't have 0x20000 bias
 		// that seem to be there for any other processes. This results in err=299.
 		// so retry with this address.
 		ProcBlock._dwCmdLineAddress |= 0x20000;
-		if(!ReadProcessMemory(hProcess, ProcBlock.dwCmdLineAddress, pszCmdLine, ProcBlock.wLength, &_)) {
-			reportError(pEnv,"Failed to read command line arguments");
+		if(!ReadProcessMemory(hProcess, ProcBlock.dwCmdLineAddress, pszCmdLine, ProcBlock.wLength, &sRead)) {
+			reportError(pEnv, "Failed to read command line arguments");
 			return NULL;
 		}
 	}
 
 	// figure out the size of the env var block
 	MEMORY_BASIC_INFORMATION info;
-	if(::VirtualQueryEx(hProcess, ProcBlock.env, &info, sizeof(info))==0) {
-		reportError(pEnv,"VirtualQueryEx failed");
+	if(VirtualQueryEx(hProcess, ProcBlock.env, &info, sizeof(info))==0) {
+		reportError(pEnv, "VirtualQueryEx failed");
 		return NULL;
 	}
 
 	int cmdLineLen = lstrlen(pszCmdLine);
 	size_t envSize = info.RegionSize;
-	auto_localmem<LPWSTR> buf = LocalAlloc(LMEM_FIXED,(cmdLineLen+1/*for \0*/)*2+envSize);
-	if(buf==NULL) {
-		reportError(pEnv,"Buffer allocation failed");
+	auto_localmem<LPWSTR> buf = LocalAlloc(LMEM_FIXED, (cmdLineLen + 1/*for \0*/) * 2 + envSize);
+	if(!buf) {
+		reportError(pEnv, "Buffer allocation failed");
 		return NULL;
 	}
-	lstrcpy(buf,pszCmdLine);
+	lstrcpy(buf, pszCmdLine);
 
-	if(!ReadProcessMemory(hProcess, ProcBlock.env, buf+cmdLineLen+1, envSize, &_)) {
-		reportError(pEnv,"Failed to read environment variable table");
+	// Checking the read size is more likely to result in success than checking the BOOL that is
+	// returned by ReadProcessMemory, on newer versions of Windows. That said, neither approach
+	// is particularly reliable past Vista. This approach differs from checking the BOOL in that
+	// it will succeed for partial reads that read _some_ data, where the other approach fails.
+	ReadProcessMemory(hProcess, ProcBlock.env, buf+cmdLineLen+1, envSize, &sRead);
+	if(!sRead) {
+		reportError(pEnv, "Failed to read environment variable table");
 		return NULL;
 	}
 
-	jstring packedStr = pEnv->NewString((jchar*)(LPWSTR)buf,cmdLineLen+1+jsize(envSize)/2);
+	jstring packedStr = pEnv->NewString((jchar*)(LPWSTR)buf, cmdLineLen + 1 + jsize(sRead) / 2);
 
 	return packedStr;
 }
@@ -123,8 +128,8 @@ JNIEXPORT jstring JNICALL Java_org_jvnet_winp_Native_getCmdLineAndEnvVars(
 JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_getProcessId(JNIEnv* pEnv, jclass clazz, jint handle) {
 	HANDLE hProcess = (HANDLE)handle;
 	PROCESS_BASIC_INFORMATION ProcInfo;
-	SIZE_T _;
-	if(!NT_SUCCESS(ZwQueryInformationProcess(hProcess, ProcessBasicInformation, &ProcInfo, sizeof(ProcInfo), &_))) {
+	SIZE_T sRead;
+	if(!NT_SUCCESS(ZwQueryInformationProcess(hProcess, ProcessBasicInformation, &ProcInfo, sizeof(ProcInfo), &sRead))) {
 		reportError(pEnv,"Failed to ZWQueryInformationProcess");
 		return -1;
 	}

--- a/java-interface.cpp
+++ b/java-interface.cpp
@@ -4,20 +4,19 @@
 #include "auto_handle.h"
 
 JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_kill(JNIEnv* env, jclass clazz, jint pid, jboolean recursive) {
-	return KillProcessEx(pid,recursive);
+	return KillProcessEx(pid, recursive);
 }
 
 JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_setPriority(JNIEnv* env, jclass clazz, jint pid, jint priority) {
-	auto_handle hProcess = OpenProcess(PROCESS_SET_INFORMATION,FALSE,pid);
-	if(!hProcess)
-		return GetLastError(); 
-	if(!SetPriorityClass(hProcess,priority))
-		return GetLastError();
-	return 0;
+	auto_handle hProcess = OpenProcess(PROCESS_SET_INFORMATION, FALSE, pid);
+	if(hProcess && SetPriorityClass(hProcess, priority)) {
+		return ERROR_SUCCESS;
+	}
+	return GetLastError();
 }
 
 JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_exitWindowsEx(JNIEnv* env, jclass _, jint uFlags, jint reasonCode) {
-	return ::ExitWindowsEx(uFlags,reasonCode);
+	return ExitWindowsEx(uFlags, reasonCode);
 }
 
 JNIEXPORT void JNICALL Java_org_jvnet_winp_Native_noop(JNIEnv* env, jclass _) {}

--- a/winp.cpp
+++ b/winp.cpp
@@ -16,20 +16,17 @@
 //  Returns:
 //	  TRUE, if successful, FALSE - otherwise.
 //
-BOOL WINAPI KillProcess(DWORD dwProcessId) {
+DWORD WINAPI KillProcess(DWORD dwProcessId) {
 	// first try to obtain handle to the process without the use of any
 	// additional privileges
 	auto_handle hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, dwProcessId);
-	if (!hProcess)
-		return FALSE;
-
-	// terminate the process
-	if (!TerminateProcess(hProcess, (UINT)-1)) {
-		return FALSE;
+	if (hProcess && TerminateProcess(hProcess, (UINT)-1)) {
+		// completed successfully
+		return ERROR_SUCCESS;
 	}
 
-	// completed successfully
-	return TRUE;
+	// either the process could not be opened or it could not be terminated
+	return GetLastError();
 }
 
 
@@ -111,14 +108,13 @@ typedef struct _SYSTEM_PROCESSES {
 //  Returns:
 //	  Win32 error code.
 //
-BOOL WINAPI KillProcessTreeNtHelper(PSYSTEM_PROCESSES pInfo, DWORD dwProcessId) {
+DWORD WINAPI KillProcessTreeNtHelper(PSYSTEM_PROCESSES pInfo, DWORD dwProcessId) {
 	_ASSERTE(pInfo != NULL);
 
     PSYSTEM_PROCESSES p = pInfo;
 
     // kill all children first
-    for (;;)
-    {
+    for (;;) {
 		if (p->InheritedFromProcessId == dwProcessId)
 			KillProcessTreeNtHelper(pInfo, p->ProcessId);
 
@@ -130,17 +126,65 @@ BOOL WINAPI KillProcessTreeNtHelper(PSYSTEM_PROCESSES pInfo, DWORD dwProcessId) 
     }
 
 	// kill the process itself
-    if (!KillProcess(dwProcessId))
+	if (!KillProcess(dwProcessId))
 		return GetLastError();
 
 	return ERROR_SUCCESS;
 }
 
+struct _TREE_PROCESS;
+typedef _TREE_PROCESS TREE_PROCESS;
+typedef _TREE_PROCESS *PTREE_PROCESS;
+
+struct _TREE_PROCESS {
+       DWORD processId;
+       PTREE_PROCESS next;
+       PTREE_PROCESS previous;
+};
+
+//---------------------------------------------------------------------------
+// FreeProcessList
+//
+//  Frees the heap memory allocated for all TREE_PROCESS entries in the list
+//  starting from the provided root element.
+//
+// Parameters:
+//  hHeap - the handle to the heap from which the elements were allocated
+//  root  - the first element in the list to free
+//
+DWORD WINAPI FreeProcessList(HANDLE hHeap, PTREE_PROCESS root) {
+	DWORD error = GetLastError(); // save the last error, in case HeapFree fails
+
+	while (root) {
+		PTREE_PROCESS temp = root;
+
+		root = root->next;
+
+		HeapFree(hHeap, 0, temp);
+	}
+
+	return error;
+}
+
 //---------------------------------------------------------------------------
 // KillProcessTreeWinHelper
 //
-//  This is a recursive helper function that terminates all the processes
-//  started by the specified process and them terminates the process itself
+//  Terminates all the processes started by the specified process and then
+//  terminates the process itself. When determining which processes were
+//  started by the specified process, the following criteria are taken into
+//  consideration:
+//  - The PPID of the process
+//  - The creation time of the process
+//
+//  Because Windows processes do not reparent (changing their PPID when their
+//  real parent process terminates before they do), the PPID of a process is
+//  not enough to safely kill a hierarchy. PID reuse can result in a process
+//  appearing to be the parent of processes it didn't actually start. To try
+//  and guard against this, the creation time (start time) for the process to
+//  terminate is compared to the creation time of any process that appears to
+//  be in its hierarchy. If the creation time of the child is before that of
+//  its parent, it is assumed that the parent "inherited" the child and did
+//  not actually start it. Such "inherited" children are not killed.
 //
 //  Parameters:
 //	  dwProcessId - identifier of the process to terminate
@@ -148,35 +192,133 @@ BOOL WINAPI KillProcessTreeNtHelper(PSYSTEM_PROCESSES pInfo, DWORD dwProcessId) 
 //  Returns:
 //	  Win32 error code.
 //
-BOOL WINAPI KillProcessTreeWinHelper(DWORD dwProcessId) {
-	// create a snapshot
+DWORD WINAPI KillProcessTreeWinHelper(DWORD dwProcessId) {
+	// first, open a handle to the process with sufficient access to query for
+	// its times. those are needed in order to filter "children" because Windows
+	// processes, unlike Unix/Linux processes, do not reparent when the process
+	// that created them exits. as a result, any process could reuse a PID and
+	// end up looking like it spawned many processes it didn't actually spawn
+	auto_handle hProcess = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwProcessId);
+	if (!hProcess) {
+		return GetLastError();
+	}
+
+	// note: processCreated will be retained as the creation time for the root
+	// process. the other variables only exist because GetProcessTimes requires
+	// all 4 pointers
+	FILETIME processCreated;
+	FILETIME exitTime;   // unused
+	FILETIME kernelTime; // unused
+	FILETIME userTime;   // unused
+	if (!GetProcessTimes(hProcess, &processCreated, &exitTime, &kernelTime, &userTime)) {
+		// if unable to check the creation time for the process, it is impossible
+		// to safely kill any children processes; just kill the root process and
+		// leave it at that
+		return KillProcess(dwProcessId);
+	}
+
+	// next, create a snapshot of all the running processes. this will be used
+	// build a graph of processes which:
+	// 1. have a parent related to the root process
+	// 2. were started after the root process
 	auto_handle hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-	if (!hSnapshot)
-		return GetLastError();
-
-	auto_localmem<PROCESSENTRY32*> pEntry = ::LocalAlloc(LMEM_FIXED|LMEM_ZEROINIT,sizeof(PROCESSENTRY32));
-
-	pEntry->dwSize = sizeof(PROCESSENTRY32);
-	if (!Process32First(hSnapshot, pEntry))
-	{
-		return GetLastError();
+	if (!hSnapshot) {
+		// if unable to open a snapshot of the currently-running processes, just
+		// kill the root process and leave it at that
+		return KillProcess(dwProcessId);
 	}
 
-	// kill all children first
-	do
-	{
-		// there was a report of infinite recursion, so watching out for the obvious self-loop possibility
-		DWORD pid = pEntry->th32ProcessID;
-		if (pEntry->th32ParentProcessID == dwProcessId && dwProcessId!=pid)
-			KillProcessTreeWinHelper(pid);
+	PROCESSENTRY32 pEntry;
+	pEntry.dwSize = sizeof(PROCESSENTRY32);
+
+	HANDLE hHeap = GetProcessHeap();
+	if (!hHeap) {
+		return KillProcess(dwProcessId);
 	}
-	while (Process32Next(hSnapshot, pEntry));
 
-	// kill the process itself
-    if (!KillProcess(dwProcessId))
-		return GetLastError();
+	PTREE_PROCESS root = (PTREE_PROCESS) HeapAlloc(hHeap, HEAP_ZERO_MEMORY, sizeof(TREE_PROCESS));
+	if (!root) {
+		// couldn't allocate memory for the TREE_PROCESS, which means we won't be able
+		// to build the list; just kill the root process and leave it at that
+		return KillProcess(dwProcessId);
+	}
+	root->processId = dwProcessId;
 
-	return ERROR_SUCCESS;
+	PTREE_PROCESS current = root;
+	PTREE_PROCESS last = root;
+
+	FILETIME creationTime; // used when getting a child's creation time
+	DWORD processId;       // holds the ID of the process being processed
+	while (current) {
+		// extract the process ID for processing, but do not move the current pointer;
+		// since children have not been processed yet, current->next may not have been
+		// set at this time. move it after the loop instead
+		processId = current->processId;
+
+		if (!Process32First(hSnapshot, &pEntry)) {
+			return FreeProcessList(hHeap, root);
+		}
+
+		// find the children for the current process
+		do {
+			DWORD pid = pEntry.th32ProcessID;
+			DWORD ppid = pEntry.th32ParentProcessID;
+
+			// first checks are the simplest; we can perform them with the data from
+			// the PROCESSENTRY32 structure:
+			// 1. does the process have a parent?
+			// 2. is the process the one we're currently checking?
+			// 3. does the process's parent match the one we're checking?
+			if (ppid == 0 || processId == pid || ppid != processId) {
+				// if any of the checks "fail", then this process is not a candidate
+				// for being killed
+				continue;
+			}
+
+			// next check: was this process, which supposedly is in our hierarchy,
+			// created before our process was? to find this out, we must open the
+			// process and check its creation time. if we cannot open the process,
+			// or we cannot get its process times, or its creation time is before
+			// its supposed parent, it is not a candidate for being killed
+			auto_handle hChild = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid);
+			if (hChild &&
+					GetProcessTimes(hChild, &creationTime, &exitTime, &kernelTime, &userTime) &&
+					CompareFileTime(&processCreated, &creationTime) < 1) {
+				// if we make it here, it means we were able to open the process,
+				// get its process times and its creation time is at or after the
+				// root process, so this process should be killed too
+				PTREE_PROCESS child = (PTREE_PROCESS) HeapAlloc(hHeap, HEAP_ZERO_MEMORY, sizeof(TREE_PROCESS));
+				if (!child) {
+					return FreeProcessList(hHeap, root);
+				}
+				child->previous = last;
+				child->processId = pid;
+
+				last->next = child;
+				last = child;
+			}
+		}
+		while (Process32Next(hSnapshot, &pEntry));
+
+		// after processing all potential children for the current process, move the
+		// pointer forward and process children for the next process in the list
+		current = current->next;
+	}
+
+	// after building the complete list, kill the processes in reverse order. the first
+	// entry in the list, and therefore the last killed, will be the root process
+	DWORD result;
+	PTREE_PROCESS temp;
+	while (last) {
+		result = KillProcess(last->processId);
+
+		temp = last;
+		last = last->previous;
+
+		HeapFree(hHeap, 0, temp);
+	}
+
+	return result;
 }
 
 //---------------------------------------------------------------------------
@@ -194,8 +336,9 @@ BOOL WINAPI KillProcessTreeWinHelper(DWORD dwProcessId) {
 //	  TRUE, if successful, FALSE - otherwise.
 //
 BOOL WINAPI KillProcessEx(DWORD dwProcessId, BOOL bTree) {
-	if (!bTree)
+	if (!bTree) {
 		return KillProcess(dwProcessId);
+	}
 
 	OSVERSIONINFO osvi;
 	DWORD dwError;
@@ -204,9 +347,7 @@ BOOL WINAPI KillProcessEx(DWORD dwProcessId, BOOL bTree) {
 	osvi.dwOSVersionInfoSize = sizeof(osvi);
 	GetVersionEx(&osvi);
 
-	if (osvi.dwPlatformId == VER_PLATFORM_WIN32_NT &&
-		osvi.dwMajorVersion < 5)
-	{
+	if (osvi.dwPlatformId == VER_PLATFORM_WIN32_NT && osvi.dwMajorVersion < 5) {
 		// obtain a handle to the default process heap
 		HANDLE hHeap = GetProcessHeap();
     
@@ -218,23 +359,20 @@ BOOL WINAPI KillProcessEx(DWORD dwProcessId, BOOL bTree) {
 		// will be enough to retrieve all information, so we start
 		// with 32K buffer and increase its size until we get the
 		// information successfully
-		do
-		{
+		do {
 			pBuffer = HeapAlloc(hHeap, 0, cbBuffer);
-			if (pBuffer == NULL)
+			if (pBuffer == NULL) {
 				return SetLastError(ERROR_NOT_ENOUGH_MEMORY), FALSE;
+			}
 
 			Status = ZwQuerySystemInformation(
 							SystemProcessesAndThreadsInformation,
 							pBuffer, cbBuffer, NULL);
 
-			if (Status == STATUS_INFO_LENGTH_MISMATCH)
-			{
+			if (Status == STATUS_INFO_LENGTH_MISMATCH) {
 				HeapFree(hHeap, 0, pBuffer);
 				cbBuffer *= 2;
-			}
-			else if (!NT_SUCCESS(Status))
-			{
+			} else if (!NT_SUCCESS(Status)) {
 				HeapFree(hHeap, 0, pBuffer);
 				return SetLastError(Status), NULL;
 			}
@@ -242,13 +380,10 @@ BOOL WINAPI KillProcessEx(DWORD dwProcessId, BOOL bTree) {
 		while (Status == STATUS_INFO_LENGTH_MISMATCH);
 
 		// call the helper function
-		dwError = KillProcessTreeNtHelper((PSYSTEM_PROCESSES)pBuffer, 
-										  dwProcessId);
+		dwError = KillProcessTreeNtHelper((PSYSTEM_PROCESSES)pBuffer, dwProcessId);
 		
 		HeapFree(hHeap, 0, pBuffer);
-	}
-	else
-	{
+	} else {
 		// call the helper function
 		dwError = KillProcessTreeWinHelper(dwProcessId);
 	}

--- a/winp.h
+++ b/winp.h
@@ -1,10 +1,10 @@
 #pragma once
 #include "stdafx.h"
 
-BOOL WINAPI KillProcessEx( IN DWORD dwProcessId, IN BOOL bTree );
+BOOL WINAPI KillProcessEx(IN DWORD dwProcessId, IN BOOL bTree);
 
 #define reportError(env,msg)	error(env,__FILE__,__LINE__,msg);
-void error( JNIEnv* env, const char* file, int line, const char* msg );
+void error(JNIEnv* env, const char* file, int line, const char* msg);
 
 
 


### PR DESCRIPTION
Premise:
Windows processes do not reset their PPIDs when they survive longer than their parent processes, meaning, through PID reuse, processes sometimes "inherit" children they didn't actually start

Solution:
- KillProcessTreeWinHelper is no longer recursive, and now only creates a single snapshot rather than one for each recursion
- The same snapshot is walked multiple times, gathering up the entire hierarchy of processes
  - The root PID being killed is used to match PPIDs to find children
  - Each child's PID is used to further match its children, iteratively
- When matching children, rather than assuming because a child's PPID matches another process's PID it really is that process's child, the child process's creation time is compared to the parent's
  - If the child is created AT or AFTER the parent, it is assumed to be a real child, rather than one inherited through PID reuse
  - If the child is created BEFORE the parent, it assumed to not be a real child and will not be killed

While testing this, I noticed that getting the command line failed pretty consistently under Windows 8 (I also verified that it appears to fail the majority of the time under Windows 7, too). Included is a slight change to have the environment variables are read in, allowing a partial read to be considered successful as long as _some_ bytes are read.
- Anecdotally, it appears sometimes the read size ends up being too large, resulting in partial reads where what was read is really all of the data available
- Modified TheTest.testGetCommandLine() to ignore any exceptions that are thrown since it iterates over every process running on the box and many of them fail (pull request #7)

Lastly, a few places where brace-on-next-line formatting was used have been reformatted to brace-on-same-line, since that appears to match the majority of the code. Additionally, added .gitignore to help ensure the compiled binaries and other Visual Studio files are not accidentally checked into the repository.
