### PR TITLE
Better report errors from corrupted JARs.

### DIFF
--- a/src/main/java/org/jvnet/winp/Native.java
+++ b/src/main/java/org/jvnet/winp/Native.java
@@ -71,7 +71,7 @@ class Native {
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);
         } catch (IOException e) {
-            throw new Error(e);
+            throw new Error("failed to checksum " + res + ": " + e, e);
         }
     }
 


### PR DESCRIPTION
Amends dc7f5b1.

```
java.io.IOException: Remote call on … failed 
    at hudson.remoting.Channel.call(Channel.java:731) 
    at hudson.Launcher$RemoteLauncher.kill(Launcher.java:887) 
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:608) 
    at hudson.model.Run.execute(Run.java:1676) 
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43) 
    at hudson.model.ResourceController.execute(ResourceController.java:88) 
    at hudson.model.Executor.run(Executor.java:231) 
Caused by: java.lang.Error: java.util.zip.ZipException: zip file is empty 
    at org.jvnet.winp.Native.md5(Native.java:74) 
    at org.jvnet.winp.Native.load(Native.java:109) 
    at org.jvnet.winp.Native.<clinit>(Native.java:55) 
    at org.jvnet.winp.WinProcess.enableDebugPrivilege(WinProcess.java:200) 
    at hudson.util.ProcessTree$Windows.<clinit>(ProcessTree.java:477) 
    at hudson.util.ProcessTree.get(ProcessTree.java:336) 
    at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:899) 
    at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:890) 
    at hudson.remoting.UserRequest.perform(UserRequest.java:118) 
    at hudson.remoting.UserRequest.perform(UserRequest.java:48) 
    at hudson.remoting.Request$2.run(Request.java:328) 
    at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72) 
    at java.util.concurrent.FutureTask$Sync.innerRun(Unknown Source) 
    at java.util.concurrent.FutureTask.run(Unknown Source) 
    at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) 
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) 
    at java.lang.Thread.run(Unknown Source) 
Caused by: java.util.zip.ZipException: zip file is empty 
    at java.util.zip.ZipFile.open(Native Method) 
    at java.util.zip.ZipFile.<init>(Unknown Source) 
    at java.util.zip.ZipFile.<init>(Unknown Source) 
    at java.util.jar.JarFile.<init>(Unknown Source) 
    at java.util.jar.JarFile.<init>(Unknown Source) 
    at sun.net.www.protocol.jar.URLJarFile.<init>(Unknown Source) 
    at sun.net.www.protocol.jar.URLJarFile.getJarFile(Unknown Source) 
    at sun.net.www.protocol.jar.JarFileFactory.get(Unknown Source) 
    at sun.net.www.protocol.jar.JarURLConnection.connect(Unknown Source) 
    at sun.net.www.protocol.jar.JarURLConnection.getInputStream(Unknown Source) 
    at java.net.URL.openStream(Unknown Source) 
    at org.jvnet.winp.Native.md5(Native.java:61) 
    ... 16 more
```
