### PR TITLE
Added property to disable unpacking .dll into jar's directory

### DIFF
--- a/src/main/java/org/jvnet/winp/Native.java
+++ b/src/main/java/org/jvnet/winp/Native.java
@@ -50,6 +50,7 @@ class Native {
     private static final Logger LOGGER = Logger.getLogger(Native.class.getName());
     // system property holding the preferred folder for copying the dll file to.
     private static final String DLL_TARGET = "winp.folder.preferred";
+    private static final String UNPACK_DLL_TO_PARENT_DIR = "winp.unpack.dll.to.parent.dir";
 
     static {
         load();
@@ -84,7 +85,12 @@ class Native {
         final URL res = Native.class.getClassLoader().getResource(dllName+".dll");
         if(res!=null) {
             String url = res.toExternalForm();
-            if(url.startsWith("jar:") || url.startsWith("wsjar:")) {
+
+          // Unpacking the dll file into the directory containing jar file can fail because
+          // the process has no rights to write to that directory.
+          boolean unpackToParentDir = Boolean.parseBoolean(System.getProperty(UNPACK_DLL_TO_PARENT_DIR));
+
+          if(unpackToParentDir && (url.startsWith("jar:") || url.startsWith("wsjar:"))) {
                 int idx = url.lastIndexOf('!');
                 String filePortion = url.substring(url.indexOf(':')+1,idx);
                 while(filePortion.startsWith("/"))


### PR DESCRIPTION
Unpacking the dll file into the directory containing jar file can fail because that directory may not be writable for the process.
