### PR TITLE
Fix for getCmdLineAndEnvVars which fails on x64 versions of Windows

### DIFF
--- a/native/envvar-cmdline.cpp
+++ b/native/envvar-cmdline.cpp
@@ -184,7 +184,8 @@ JNIEXPORT jstring JNICALL Java_org_jvnet_winp_Native_getCmdLineAndEnvVars(
 	}
 
 	int cmdLineLen = lstrlen(pszCmdLine);
-	size_t envSize = info.RegionSize;
+	size_t envSize = info.RegionSize - ((char*)pEnvStr - (char*)info.BaseAddress);
+	
 	auto_localmem<LPWSTR> buf((cmdLineLen + 1/*for \0*/) * 2 + envSize);
 	if(!buf) {
 		reportError(pEnv, "Buffer allocation failed");


### PR DESCRIPTION
In March 2010, *eifert* reported an issue about `getCmdLineAndEnvVars` which was failing on X64 versions of Windows [1]. I have encountered the same issue with winp in version 1.23.

I have updated and applied the fix to the current version of winp. As a consequence, the issue I have observed on Windows 8.1 Pro seems resolved. It would be really great if the change can be reviewed and applied in the original project.

[1] https://java.net/jira/browse/WINP-10