### PR TITLE
Fixes #28 - do not require PROCESS_TERMINATE in Java_org_jvnet_winp_Native_isCriticalProcess()

### DIFF
--- a/native/winp.cpp
+++ b/native/winp.cpp
@@ -417,7 +417,7 @@ BOOL WINAPI KillProcessEx(DWORD dwProcessId, BOOL bTree) {
 JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_isCriticalProcess(JNIEnv* pEnv, jclass clazz, jint dwProcessId) {
 	// first try to obtain handle to the process without the use of any
 	// additional privileges
-	auto_handle hProcess = OpenProcess(PROCESS_TERMINATE|PROCESS_QUERY_INFORMATION, FALSE, dwProcessId);
+	auto_handle hProcess = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwProcessId);
 	if (!hProcess)
 		return FALSE;
 


### PR DESCRIPTION
See #28 , likely it's a copy-paste mistake made by @kohsuke long-long ago. It does not heavily impact the existing usages though.

@reviewbybees