### PR TITLE
Issue #29 - Do not retrieve Environment variables just to get the command line

### DIFF
--- a/native/java-interface.h
+++ b/native/java-interface.h
@@ -48,6 +48,14 @@ JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_exitWindowsEx
   (JNIEnv *, jclass, jint, jint);
 
 /*
+* Class:     org_jvnet_winp_Native
+* Method:    getCmdLine
+* Signature: (I)Ljava/lang/String;
+*/
+JNIEXPORT jstring JNICALL Java_org_jvnet_winp_Native_getCmdLine
+(JNIEnv *, jclass, jint);
+
+/*
  * Class:     org_jvnet_winp_Native
  * Method:    getCmdLineAndEnvVars
  * Signature: (I)Ljava/lang/String;

--- a/src/main/java/org/jvnet/winp/Native.java
+++ b/src/main/java/org/jvnet/winp/Native.java
@@ -29,12 +29,21 @@ class Native {
     /**
      * Gets the command line and environment variables of the process
      * identified by the process ID.
+     * If the environment variables are not required, consider using {@link #getCmdLine(int)}.
      *
      * <p>
      * To simplify the JNI side, the resulting string is structured to
      * "cmdlineargs\0env1=val1\0env2=val2\0..."
      */
     native static String getCmdLineAndEnvVars(int pid);
+    
+    /**
+     * Gets the command line of the process identified by the process ID.
+     * @param pid Process ID
+     * @return Command line or {@code null} if it cannot be retrieved
+     * @throws WinpException Operation failure
+     */
+    native static String getCmdLine(int pid) throws WinpException;
 
     /**
      * Enumerate all processes.

--- a/src/main/java/org/jvnet/winp/WinProcess.java
+++ b/src/main/java/org/jvnet/winp/WinProcess.java
@@ -103,8 +103,9 @@ public class WinProcess {
      *      maybe we didn't have enough security privileges.
      */
     public synchronized String getCommandLine() {
-        if(commandline==null)
-            parseCmdLineAndEnvVars();
+        if(commandline == null) {
+            parseCmdLine();
+        }
         return commandline;
     }
 
@@ -127,6 +128,14 @@ public class WinProcess {
         return envVars;
     }
 
+    private void parseCmdLine() throws WinpException {
+        String s = Native.getCmdLine(pid);
+        if(s == null) {
+            throw new WinpException("Failed to obtain command line for PID = " + pid); 
+        }
+        commandline = s;
+    }
+    
     private void parseCmdLineAndEnvVars() {
         String s = Native.getCmdLineAndEnvVars(pid);
         if(s==null)

--- a/src/test/java/org/jvnet/winp/NativeAPITest.java
+++ b/src/test/java/org/jvnet/winp/NativeAPITest.java
@@ -61,6 +61,8 @@ public class NativeAPITest extends Assert {
     public void testGetCommandLine() {
         int failed = 0;
         int total = 0;
+        
+        // Generally this test is unreliable, 299 does not always happen even on Vista+ platforms
         for (WinProcess p : WinProcess.all()) {
             if (p.getPid() < 10) {
                 continue;
@@ -80,12 +82,14 @@ public class NativeAPITest extends Assert {
                     // On Vista and higher, the most common error here is 299, ERROR_PARTIAL_COPY. A bit of
                     // research online seems to suggest that's related to how those versions of Windows use
                     // randomized memory locations for process's
-                    System.out.println("Unexpected failure getting command line for process " + p.getPid() +
+                    Assert.fail("Unexpected failure getting command line for process " + p.getPid() +
                             ": (" + e.getWin32ErrorCode() + ") " + e.getMessage());
                 }
             }
         }
-        System.out.println("Failed to get command lines for " + failed + " of " + total + " processes");
+        if (failed != 0) {
+            System.out.println("Failed to get command lines for " + failed + " of " + total + " processes");
+        }
     }
 
     @Test(expected = WinpException.class)


### PR DESCRIPTION
It does not resolve the issue #29 , but it reduces its scope to API users, which actually do not 
require Environment Variables. Unfortunately [JENKINS-30782](https://issues.jenkins-ci.org/browse/JENKINS-30782) is of such kind, because Jenkins process termination logic for builds relies on the environment variables.

OTOH, it is still a useful performance improvement

@reviewbybees