### PR TITLE
Make WinP Debuggable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,14 +21,15 @@ install:
 
 # Build and test  
 build_script:
-  - .\build.cmd cleanbuild Release %APPVEYOR_BUILD_VERSION%
-  - ps: Get-ChildItem target\winp-$env:APPVEYOR_BUILD_VERSION.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
   - .\build.cmd cleanbuild Debug %APPVEYOR_BUILD_VERSION%-Debug
   - ps: Get-ChildItem target\winp-$env:APPVEYOR_BUILD_VERSION-Debug.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
+  - .\build.cmd cleanbuild Release %APPVEYOR_BUILD_VERSION%
+  - ps: Get-ChildItem target\winp-$env:APPVEYOR_BUILD_VERSION.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
+
 
 on_finish:
-# TODO: enable once there are tests, implement aggregator somehow 
-# - ps: (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))
+  # Publish JUnit reports for the release version
+  - ps: Get-ChildItem target\surefire-reports\TEST-*.xml | (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path target\surefire-reports\$_.Name))
 
 artifacts:
 #x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,15 +21,14 @@ install:
 
 # Build and test  
 build_script:
-  - .\build.cmd cleanbuild Debug %APPVEYOR_BUILD_VERSION%-Debug
-  - ps: Get-ChildItem target\winp-$env:APPVEYOR_BUILD_VERSION-Debug.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
   - .\build.cmd cleanbuild Release %APPVEYOR_BUILD_VERSION%
   - ps: Get-ChildItem target\winp-$env:APPVEYOR_BUILD_VERSION.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
-
+  - .\build.cmd cleanbuild Debug %APPVEYOR_BUILD_VERSION%-Debug
+  - ps: Get-ChildItem target\winp-$env:APPVEYOR_BUILD_VERSION-Debug.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
 
 on_finish:
-  # Publish JUnit reports for the release version
-  - ps: Get-ChildItem target\surefire-reports\TEST-*.xml | (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path target\surefire-reports\$_.Name))
+# TODO: enable once there are tests, implement aggregator somehow 
+# - ps: (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests.xml))
 
 artifacts:
 #x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@
 skip_tags: true
 skip_branch_with_pr: true
 
+version: 1.25.0.{build}-SNAPSHOT
+
 # MVS Project configuration
 image: Visual Studio 2013
 platform: Any CPU
@@ -19,10 +21,10 @@ install:
 
 # Build and test  
 build_script:
-  - .\build.cmd cleanbuild Release {version}
-  - ps: Get-ChildItem target\winp-{version}.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
-  - .\build.cmd cleanbuild Debug {version}-Debug
-  - ps: Get-ChildItem target\winp-{version}-Debug.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
+  - .\build.cmd cleanbuild Release $(appveyor_build_version)
+  - ps: Get-ChildItem target\winp-$(appveyor_build_version).jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
+  - .\build.cmd cleanbuild Debug $(appveyor_build_version)-Debug
+  - ps: Get-ChildItem target\winp-$(appveyor_build_version)-Debug.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
 
 on_finish:
 # TODO: enable once there are tests, implement aggregator somehow 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,11 +19,10 @@ install:
 
 # Build and test  
 build_script:
-  - .\build.cmd cleanbuild
-
-# Publish the JAR file as an artifact
-after_build:
-  - ps: Get-ChildItem target\winp-*.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }  
+  - .\build.cmd cleanbuild Release {version}
+  - ps: Get-ChildItem target\winp-{version}.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
+  - .\build.cmd cleanbuild Debug {version}-Debug
+  - ps: Get-ChildItem target\winp-{version}-Debug.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
 
 on_finish:
 # TODO: enable once there are tests, implement aggregator somehow 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,10 @@ install:
 
 # Build and test  
 build_script:
-  - .\build.cmd cleanbuild Release $(appveyor_build_version)
-  - ps: Get-ChildItem target\winp-$(appveyor_build_version).jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
-  - .\build.cmd cleanbuild Debug $(appveyor_build_version)-Debug
-  - ps: Get-ChildItem target\winp-$(appveyor_build_version)-Debug.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
+  - .\build.cmd cleanbuild Release %APPVEYOR_BUILD_VERSION%
+  - ps: Get-ChildItem target\winp-$env:APPVEYOR_BUILD_VERSION.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
+  - .\build.cmd cleanbuild Debug %APPVEYOR_BUILD_VERSION%-Debug
+  - ps: Get-ChildItem target\winp-$env:APPVEYOR_BUILD_VERSION-Debug.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
 
 on_finish:
 # TODO: enable once there are tests, implement aggregator somehow 

--- a/build.cmd
+++ b/build.cmd
@@ -14,7 +14,7 @@ if "%3"=="" (
 	echo No target version specified, will determine it from POM
 	REM TODO: Apply some MADSKILLZ to do it without the temporary file?
 	call mvn -q -Dexec.executable="cmd.exe" -Dexec.args="/c echo ${project.version}" --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec > version.txt
-	set version=<version.txt
+	for /f "delims=" %%x in (version.txt) do set version=%%x
 ) else (
 	echo Setting MVN project version to the externally defined %3%
 	set version=%3%	

--- a/build.cmd
+++ b/build.cmd
@@ -54,7 +54,9 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo ### Build and Test winp.jar for %version%
 cd %BUIDROOT%
-call mvn --batch-mode versions:set clean package verify -DnewVersion=%version%
+call mvn -q --batch-mode versions:set -DnewVersion=%version%
+if %errorlevel% neq 0 exit /b %errorlevel%
+call mvn --batch-mode clean package verify 
 if %errorlevel% neq 0 exit /b %errorlevel%
 goto :exit
 

--- a/build.cmd
+++ b/build.cmd
@@ -4,6 +4,23 @@ set PATH=%PATH%;%ProgramFiles(x86)%\MSBuild\12.0\Bin\;
 set BUIDROOT=%cd%
 
 :getopts
+if "%2"=="" (
+	set configuration="Release"
+) else (
+	set configuration=%2%
+)
+
+if "%3"=="" (
+	echo No target version specified, will determine it from POM
+	REM TODO: Apply some MADSKILLZ to do it without the temporary file?
+	call mvn -q -Dexec.executable="cmd.exe" -Dexec.args="/c echo ${project.version}" --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec > version.txt
+	set version=<version.txt
+) else (
+	echo Setting MVN project version to the externally defined %3%
+	set version=%3%	
+)
+echo Target version is %version%
+
 if "%1"=="" (goto :default) else (goto :%1)
 goto :exit
 
@@ -11,41 +28,33 @@ goto :exit
 goto :cleanbuild
 
 :cleanbuild
-echo "### Cleaning the build directory"
+echo ### Cleaning the %configuration% build directory
 cd %BUIDROOT%\native
-msbuild winp.vcxproj /t:Clean /p:Configuration=Release /verbosity:minimal /nologo /p:Platform="Win32"
+msbuild winp.vcxproj /t:Clean /p:Configuration=%configuration% /verbosity:minimal /nologo /p:Platform="Win32"
 if %errorlevel% neq 0 exit /b %errorlevel%
-msbuild winp.vcxproj /t:Clean /p:Configuration=Release /verbosity:minimal /nologo /p:Platform="x64"
-if %errorlevel% neq 0 exit /b %errorlevel%
-msbuild winp.vcxproj /t:Clean /p:Configuration=Debug /verbosity:minimal /nologo /p:Platform="Win32"
-if %errorlevel% neq 0 exit /b %errorlevel%
-msbuild winp.vcxproj /t:Clean /p:Configuration=Debug /verbosity:minimal /nologo /p:Platform="x64"
+msbuild winp.vcxproj /t:Clean /p:Configuration=%configuration% /verbosity:minimal /nologo /p:Platform="x64"
 if %errorlevel% neq 0 exit /b %errorlevel%
 goto :build
 
 :build
-echo "### Building project configurations"
+echo ### Building the %configuration% configuration
 cd %BUIDROOT%\native
 REM /verbosity:minimal
-msbuild winp.vcxproj /p:Configuration=Release /nologo /p:Platform="Win32"
+msbuild winp.vcxproj /p:Configuration=%configuration% /nologo /p:Platform="Win32"
 if %errorlevel% neq 0 exit /b %errorlevel%
-msbuild winp.vcxproj /p:Configuration=Release /nologo /p:Platform="x64"
-if %errorlevel% neq 0 exit /b %errorlevel%
-msbuild winp.vcxproj /p:Configuration=Debug /nologo /p:Platform="Win32"
-if %errorlevel% neq 0 exit /b %errorlevel%
-msbuild winp.vcxproj /p:Configuration=Debug /nologo /p:Platform="x64"
+msbuild winp.vcxproj /p:Configuration=%configuration% /nologo /p:Platform="x64"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-echo "### Updating WinP resource files"
+echo ### Updating WinP resource files for the %configuration% build
 cd %BUIDROOT%
-COPY native\Release\winp.dll src\main\resources\winp.dll
+COPY native\%configuration%\winp.dll src\main\resources\winp.dll
 if %errorlevel% neq 0 exit /b %errorlevel%
-COPY native\x64\Release\winp.dll src\main\resources\winp.x64.dll
+COPY native\x64\%configuration%\winp.dll src\main\resources\winp.x64.dll
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-echo "### Build and Test winp.jar"
+echo ### Build and Test winp.jar for %version%
 cd %BUIDROOT%
-mvn --batch-mode clean package verify
+call mvn --batch-mode versions:set clean package verify -DnewVersion=%version%
 if %errorlevel% neq 0 exit /b %errorlevel%
 goto :exit
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>
@@ -38,6 +39,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.20</version>
         <configuration>
           <forkMode>never</forkMode>
         </configuration>
@@ -69,6 +71,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
Idea of this change is to provide a debuggable version of WinP, which allows attaching debugger to java process utilizing it in order to debug the native part.

- [x] - Start building JAR bundle with Debug versions of DLLs (symbols will be published on AppVeyor)
- [x] - Explicitly specify mvn package versions in the build flow
- [x] - Rework `build.cmd` to take more parameters
- [x] - In Appveyor builds use the locally defined version