### PR TITLE
[Issue #29] - Improve diagnostics of Process reading in the native code

### DIFF
--- a/native/envvar-cmdline.cpp
+++ b/native/envvar-cmdline.cpp
@@ -227,9 +227,15 @@ jstring getCmdLineAndEnvVars(
 		return NULL;
 	}
 
+	if (pEnvStr < info.BaseAddress) {
+		sprintf_s<ERRMSG_SIZE>(errorBuffer, "Process memory header has been read incorrectly. Environment Table points to the address lower than the start address of the region (base=%p, envPointer=%p)", pEnvStr, pEnvStr);
+		reportError(pEnv, errorBuffer);
+		return NULL;
+	}
+
 	size_t bytesBeforeEnv = (char*)pEnvStr - (char*)info.BaseAddress;
 	if (bytesBeforeEnv > info.RegionSize) {
-		sprintf_s<ERRMSG_SIZE>(errorBuffer, "Process memory header has been read incorrectly. Environment Table points to an address from outside of the region (base=%p, size=%d, envPointer=%p)", pEnvStr, info.RegionSize, pEnvStr);
+		sprintf_s<ERRMSG_SIZE>(errorBuffer, "Process memory header has been read incorrectly. Environment Table points to the address beyond the max address of the region (base=%p, size=%d, envPointer=%p)", pEnvStr, info.RegionSize, pEnvStr);
 		reportError(pEnv, errorBuffer);
 		return NULL;
 	}

--- a/native/runtime.cpp
+++ b/native/runtime.cpp
@@ -1,7 +1,12 @@
 #include "stdafx.h"
+#include "winp.h"
+
+LPFN_ISWOW64PROCESS fnIsWow64Process;
 
 extern "C"
 BOOL WINAPI _DllMainCRTStartup(HANDLE  hDllHandle, DWORD   dwReason, LPVOID  lpreserved) {
+	fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(
+		GetModuleHandle(TEXT("kernel32")), "IsWow64Process");
 	return TRUE;
 }
 

--- a/native/runtime.cpp
+++ b/native/runtime.cpp
@@ -4,7 +4,7 @@
 LPFN_ISWOW64PROCESS fnIsWow64Process;
 
 extern "C"
-BOOL WINAPI _DllMainCRTStartup(HANDLE  hDllHandle, DWORD   dwReason, LPVOID  lpreserved) {
+BOOL WINAPI DllMain(HANDLE hInst, ULONG dwReason, LPVOID lpReserved) {
 	fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(
 		GetModuleHandle(TEXT("kernel32")), "IsWow64Process");
 	return TRUE;

--- a/native/winp.h
+++ b/native/winp.h
@@ -1,17 +1,23 @@
 #pragma once
 #include "stdafx.h"
 
-BOOL WINAPI KillProcessEx(IN DWORD dwProcessId, IN BOOL bTree);
-
+// Sets bit 29 in order to keep the codes in the user space
+#define reportErrorWithCode(env,code,msg)	SetLastError(code + 0x10000000); error(env,__FILE__,__LINE__,msg);
 #define reportError(env,msg)	error(env,__FILE__,__LINE__,msg);
 void error(JNIEnv* env, const char* file, int line, const char* msg);
 
-
-
 //
+// Kernel32.dll
+//
+BOOL WINAPI KillProcessEx(IN DWORD dwProcessId, IN BOOL bTree);
+// https://msdn.microsoft.com/en-us/library/ms684139.aspx
+extern "C" BOOL WINAPI IsWow64Process(HANDLE, PBOOL);
+// https://msdn.microsoft.com/en-us/library/ms683189(VS.85).aspx
+//BOOL WINAPI GetExitCodeProcess(HANDLE, LPDWORD);
+//VOID WINAPI SetLastError(DWORD);
+
 //
 // NTDLL functions
-//
 //
 
 // see http://msdn2.microsoft.com/en-us/library/aa489609.aspx
@@ -33,7 +39,7 @@ enum MBI_REGION_STATE : DWORD {
 };
 
 enum MBI_REGION_PROTECT : DWORD {
-	/// For MEMORY_BASIC_IONFORMATION#Prptect
+	/// For MEMORY_BASIC_IONFORMATION#Protect
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366786(v=vs.85).aspx
 	NoAccessToCheck = 0,
 	NoAccess = PAGE_NOACCESS,

--- a/native/winp.h
+++ b/native/winp.h
@@ -9,12 +9,14 @@ void error(JNIEnv* env, const char* file, int line, const char* msg);
 //
 // Kernel32.dll
 //
+
 BOOL WINAPI KillProcessEx(IN DWORD dwProcessId, IN BOOL bTree);
+
 // https://msdn.microsoft.com/en-us/library/ms684139.aspx
-extern "C" BOOL WINAPI IsWow64Process(HANDLE, PBOOL);
-// https://msdn.microsoft.com/en-us/library/ms683189(VS.85).aspx
-//BOOL WINAPI GetExitCodeProcess(HANDLE, LPDWORD);
-//VOID WINAPI SetLastError(DWORD);
+typedef BOOL(WINAPI *LPFN_ISWOW64PROCESS) (HANDLE, PBOOL);
+// Reference to the IsWow64Process method.
+// It is being handled via the reference, because the method is not available for the non-desktop-app mode (e.g. Windows service or AppVeyor build)
+extern LPFN_ISWOW64PROCESS fnIsWow64Process;
 
 //
 // NTDLL functions

--- a/native/winp.h
+++ b/native/winp.h
@@ -24,6 +24,32 @@ enum PROCESSINFOCLASS {
 	ProcessBreakOnTermination = 29,
 };
 
+enum MBI_REGION_STATE : DWORD {
+	/// For MEMORY_BASIC_IONFORMATION#State
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366775(v=vs.85).aspx
+	Allocated = MEM_COMMIT,
+	Free = MEM_FREE,
+	Reserved = MEM_RESERVE
+};
+
+enum MBI_REGION_PROTECT : DWORD {
+	/// For MEMORY_BASIC_IONFORMATION#Prptect
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366786(v=vs.85).aspx
+	NoAccessToCheck = 0,
+	NoAccess = PAGE_NOACCESS,
+	// Documentation does not really say it is not readable, but it seems so according to the samples in the internet and existense of PAGE_EXECUTE_READ
+	ExecuteOnly = PAGE_EXECUTE
+	//TODO: Add other flags on-demand
+};
+
+enum MBI_REGION_TYPE : DWORD {
+	/// For MEMORY_BASIC_IONFORMATION#Type
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366775(v=vs.85).aspx
+	Image = MEM_IMAGE,
+	Mapped = MEM_MAPPED,
+	Private = MEM_PRIVATE
+};
+
 extern "C" NTSTATUS NTAPI ZwQueryInformationProcess(HANDLE hProcess, PROCESSINFOCLASS infoType, /*out*/ PVOID pBuf, /*sizeof pBuf*/ ULONG lenBuf, SIZE_T* /*PULONG*/ returnLength); 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
+        <configuration>
+            <argLine>-XX:+CreateMinidumpOnCrash</argLine>
+            <trimStackTrace>false</trimStackTrace>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/org/jvnet/winp/UserErrorType.java
+++ b/src/main/java/org/jvnet/winp/UserErrorType.java
@@ -21,40 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package org.jvnet.winp;
 
-package org.jvnet.winp.util;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import org.hamcrest.core.StringContains;
-import org.junit.Assume;
+import javax.annotation.Nonnegative;
 
 /**
- * Test helpers for the WinP library.
+ * User-scope error codes in WinP. 
  * @author Oleg Nenashev
  */
-public class TestHelper {
+enum UserErrorType {
+    PROCESS_IS_NOT_RUNNING(1),
+    QUERY_64BIT_PROC_FROM_32BIT(2);
     
-    /**
-     * Checks if current system is Windows and skips the test otherwise.
-     */
-    public static void assumeIsWindows() {
-        Assume.assumeThat("The test utilizes the native WinP Library. It can be executed on Windows only.", 
-                System.getProperty("os.name"), StringContains.containsString("Windows"));
+    private final int shortCode;
+    
+    UserErrorType(@Nonnegative int shortCode) {
+        this.shortCode = shortCode;
+    }
+
+    public int getShortCode() {
+        return shortCode;
     }
     
-    /**
-     * Checks if current system is 64bit and skips the test otherwise.
-     */
-    public static void assumeIs64BitHost() {
-        Assume.assumeThat("This test can run ony on 64-bit platforms.", 
-                System.getProperty("sun.arch.data.model"), equalTo("64"));
+    public int getSystemErrorCode() {
+        return toSystemErrorCode(shortCode);
     }
     
-    public static boolean is64BitJVM() {
-        return "64".equals(System.getProperty("sun.arch.data.model"));
+    public boolean matches(int systemCode) {
+        return systemCode == toSystemErrorCode(shortCode);
     }
     
-    public static boolean is32BitJVM() {
-        return "32".equals(System.getProperty("sun.arch.data.model"));
+    // TODO: refactor to Enum in the API
+    private static int toSystemErrorCode(int minor) {
+        return 0x10000000 + minor;
     }
 }

--- a/src/test/java/org/jvnet/winp/PlatformSpecificProcessTest.java
+++ b/src/test/java/org/jvnet/winp/PlatformSpecificProcessTest.java
@@ -90,16 +90,17 @@ public class PlatformSpecificProcessTest extends ProcessSpawningTest {
     @Test
     public void getCommandLine_shouldNotFailIfTheProcessIsDead() throws Exception {
         Process p = spawnTestApp();
-        new WinProcess(p).killRecursively();
+        WinProcess wp = new WinProcess(p);
+        int pid = wp.getPid();
+        wp.killRecursively();
         Thread.sleep(1000);
         assertFalse("The process has not been stopped yet", isAlive(p));
 
         try {
             new WinProcess(p).getCommandLine();
         } catch (WinpException ex) {
-            assertThat(ex.getMessage(), allOf(
-                    containsString("Failed to read " + getExpectedPEBName(false)), 
-                    containsString("error=299 at envvar-cmdline")));
+            assertThat(ex.getMessage(), containsString("Process with pid=" + pid + " has already stopped. Exit code is -1"));
+            assertThat(ex.getWin32ErrorCode(), equalTo(UserErrorType.PROCESS_IS_NOT_RUNNING.getSystemErrorCode()));
             return;
         }
         
@@ -109,16 +110,17 @@ public class PlatformSpecificProcessTest extends ProcessSpawningTest {
     @Test
     public void getEnvironmentVariables_shouldFailIfTheProcessIsDead() throws Exception {
         Process p = spawnTestApp();
-        new WinProcess(p).killRecursively();
+        WinProcess wp = new WinProcess(p);
+        int pid = wp.getPid();
+        wp.killRecursively();
         Thread.sleep(1000);
         assertFalse("The process has not been stopped yet", isAlive(p));
         
         try {
             new WinProcess(p).getEnvironmentVariables();
         } catch (WinpException ex) {
-            assertThat(ex.getMessage(), allOf(
-                    containsString("Failed to read " + getExpectedPEBName(false)), 
-                    containsString("error=299 at envvar-cmdline")));
+            assertThat(ex.getMessage(), containsString("Process with pid=" + pid + " has already stopped. Exit code is -1"));
+            assertThat(ex.getWin32ErrorCode(), equalTo(UserErrorType.PROCESS_IS_NOT_RUNNING.getSystemErrorCode()));
             return;
         }
         


### PR DESCRIPTION
This change should significantly improve the diagnostics info for #29 in some corner cases. All the issues below may lead to #29 or to "Failed to read PEB" (e.g. [JENKINS-8614](https://issues.jenkins-ci.org/browse/JENKINS-8614) in Jenkins tests)

Native:

- [x] Enable CRT in the Release build. It makes the DLL 5 times bigger (<10 KB => 50KB), but allows doing fine-grain logging. I can make it a non-default behavior if it is preferred
- [x] Return explicit error if the process is no longer running
- [x] Return explicit error if we try to poll the 64bit process from a 32bit JVM (probably it is a way to do it in WinP by dirty hacks, but I would not expect any other stuff in Jenkins to work reliably in such case - leads to #29 or PEB error)
- [x] Return explicit errors if the Process Memory region is not readable && we want to read EnvVars from there. For newly created processes it will lead to #29 (Header is ready, but memory region is not ready)
- [x] Return explicit error if the code is messed up, and the Environment pointer is incorrect (e.g. we read RTL_USER_PROCESS_PARAMETERS incorrectly, leads to #29)

Java:

- [x] Enable stacktraces and core dumps for the build failure
- [x] More tests

Work is in progress, because AppVeyor JVM was crashing, need to investigate. likely it is due to the `isWow64()` method, where I oversimplified the pattern once the simple approach worked.

@reviewbybees