### PR TITLE
Extend WinP documentation

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,49 @@
+WinP Developer info
+---
+
+## Building
+
+In order to build and test the project, use the `build.cmd` script available in the repository. 
+In order to build the project, you need Microsoft Visual Studio 2013 or above.
+
+* `build.cmd cleanbuild` - Build and test the release version of the JAR file.
+Code will not be signed automatically.
+* `build.cmd cleanbuild Debug` - Build and test the Debug configuration of the library. 
+This version simplifies debugging of the native part of the library (see below).
+
+## Testing
+
+* Right now all tests are implemented in Java part of the library (JUnit Framework).
+There is no fully native tests.
+* All tests are being automatically invoked by `build.cmd`
+* Tests run from Maven, and the selected 32/64-bit mode depends on the Java version, 
+which can be passed to maven using the `JAVA_HOME` environment variable.
+* Generally you need to run `build.cmd cleanbuild Debug` and `build.cmd cleanbuild Release` on 3 configurations
+  * 32-bit Windows, 32-bit Java
+  * 64-bit Windows, 64-bit Java
+  * 64-bit Windows, 32-bit Java (WoW64 mode)
+
+Note that WinP behavior may differ depending on the Windows version, permissions, run mode (desktop/service), etc.
+Ideally, tests should be executed on all target platforms.
+
+## Continuous Integration
+
+Project has a continuous integration flow being hosted by AppVeyor ([project page](https://ci.appveyor.com/project/oleg-nenashev/winp)).
+This CI instance automates testing of Debug and Release configurations, 
+but it does not provide full coverage of possible system configurations.
+See [the appveyor.yml file](./appveyor.yml) for more details.
+
+## Debugging
+
+### Debugging Java part
+
+Java part of the library can be debugged independently or within a project using standard tools available in the Java Development Kit.
+ 
+### Debugging Native part
+
+In order to debug native parts of the library attach your debugger (e.g. from Microsoft Visual Studio UI) to the `java.exe` process.
+Then you can load debug symbols provided within native build directories (or in AppVeyor).
+Symbols are available for both Release and Debug configurations, but debug configuration provides more information.
+
+When debugging code in Microsoft Visual Studio, make sure that the selected `Configuration` and `Platform` in UI are similar to the built version and to the Java version (32/64 bit).
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,36 @@ Features summary:
 * Process info acquisition
 * etc.
 
-See [the library's javadoc][javadoc] for more details.
+See [the library's Javadoc][javadoc] for more details.
+
+## Java support
+
+Starting from `winp-1.25`, the library supports versions from Java 1.6 to Java 8. 
+Currently pre-release Java 9 versions are not being tested.
+ 
+WinP Library includes native libraries for all supported platforms, hence it can run on both 32bit and 64bit Java versions without any additional configuration.
+
+## Platform support
+
+The library supports _x86_ and _amd64_ architectures.
+ARM architecture is not supported.
+Please raise an issue to the library if you need ARM support && ready to provide proper test environment.
+
+:exclamation: It is **not recommended** to use WinP with _32bit_ Java on a _64bit_ operating system. 
+In such case the library will be running in the WoW64 mode; 
+and it will be unable to properly work with 64bit processes in the system.
+E.g. any process information query call (e.g. Environment variables retrieval) may fail if you run it against 64bit process.
+
+## Supported Windows versions
+
+The current version of WinP is known to work correctly on the following Windows versions:
+
+* Windows XP SP2 and above
+* Windows Server 2003 and above
+
+Other Windows product lines are not being actively tested though WinP may work there.
+
+:exclamation: Minimal required Windows version is a subject to change in next releases of WinP.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Windows process management library (WinP)
 
+[![Build status](https://ci.appveyor.com/api/projects/status/0w6ivhpkt20d88md?svg=true)](https://ci.appveyor.com/project/oleg-nenashev/winp)
+
 This project develops a library that lets you control Windows processes better, beyond what's available in JDK. 
 
 Features summary:


### PR DESCRIPTION
This is a heads-up change in documentation, which is a prerequisite for 32bit Java support notes I am going to write in the Jenkins project.

- [x] Explicitly mention supported Java/Windows versions and platforms
- [x] Explicitly mention limitations in the case of "Windows 64bit with Java 32bit" mode
- [x] Add developer guide
- [x] Add the AppVeyor badge 

@reviewbybees @kohsuke