### PR TITLE
Add sendCtrlC method

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -34,6 +34,10 @@ msbuild winp.vcxproj /t:Clean /p:Configuration=%configuration% /verbosity:minima
 if %errorlevel% neq 0 exit /b %errorlevel%
 msbuild winp.vcxproj /t:Clean /p:Configuration=%configuration% /verbosity:minimal /nologo /p:Platform="x64"
 if %errorlevel% neq 0 exit /b %errorlevel%
+msbuild sendctrlc\sendctrlc.vcxproj /t:Clean /p:Configuration=Release /verbosity:minimal /nologo /p:Platform="Win32"
+if %errorlevel% neq 0 exit /b %errorlevel%
+msbuild sendctrlc\sendctrlc.vcxproj /t:Clean /p:Configuration=Release /verbosity:minimal /nologo /p:Platform="x64"
+if %errorlevel% neq 0 exit /b %errorlevel%
 msbuild ..\native_test\testapp\testapp.vcxproj /t:Clean /p:Configuration=Release /verbosity:minimal /nologo /p:Platform="Win32"
 if %errorlevel% neq 0 exit /b %errorlevel%
 msbuild ..\native_test\testapp\testapp.vcxproj /t:Clean /p:Configuration=Release /verbosity:minimal /nologo /p:Platform="x64"
@@ -48,6 +52,10 @@ msbuild winp.vcxproj /p:Configuration=%configuration% /nologo /p:Platform="Win32
 if %errorlevel% neq 0 exit /b %errorlevel%
 msbuild winp.vcxproj /p:Configuration=%configuration% /nologo /p:Platform="x64"
 if %errorlevel% neq 0 exit /b %errorlevel%
+msbuild sendctrlc\sendctrlc.vcxproj /p:Configuration=%configuration% /nologo /p:Platform="Win32"
+if %errorlevel% neq 0 exit /b %errorlevel%
+msbuild sendctrlc\sendctrlc.vcxproj /p:Configuration=%configuration% /nologo /p:Platform="x64"
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo ### Building test applications
 msbuild ..\native_test\testapp\testapp.vcxproj /verbosity:minimal /p:Configuration=Release /nologo /p:Platform="Win32"
@@ -60,6 +68,10 @@ cd %BUIDROOT%
 COPY native\%configuration%\winp.dll src\main\resources\winp.dll
 if %errorlevel% neq 0 exit /b %errorlevel%
 COPY native\x64\%configuration%\winp.dll src\main\resources\winp.x64.dll
+if %errorlevel% neq 0 exit /b %errorlevel%
+COPY native\sendctrlc\Win32\%configuration%\sendctrlc.exe src\main\resources\sendctrlc.exe
+if %errorlevel% neq 0 exit /b %errorlevel%
+COPY native\sendctrlc\x64\%configuration%\sendctrlc.exe src\main\resources\sendctrlc.x64.exe
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo ### Build and Test winp.jar for %version%

--- a/native/java-interface.cpp
+++ b/native/java-interface.cpp
@@ -7,6 +7,10 @@ JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_kill(JNIEnv* env, jclass c
 	return KillProcessEx(pid, recursive);
 }
 
+JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_sendCtrlC(JNIEnv* env, jclass clazz, jint pid) {
+  return SendCtrlC(pid);
+}
+
 JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_setPriority(JNIEnv* env, jclass clazz, jint pid, jint priority) {
 	auto_handle hProcess = OpenProcess(PROCESS_SET_INFORMATION, FALSE, pid);
 	if(hProcess && SetPriorityClass(hProcess, priority)) {

--- a/native/java-interface.cpp
+++ b/native/java-interface.cpp
@@ -7,8 +7,9 @@ JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_kill(JNIEnv* env, jclass c
 	return KillProcessEx(pid, recursive);
 }
 
-JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_sendCtrlC(JNIEnv* env, jclass clazz, jint pid) {
-  return SendCtrlC(pid);
+JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_sendCtrlC(JNIEnv* env, jclass clazz, jint pid, jstring sendctrlcExePath) {
+  const wchar_t* exePath = (wchar_t*)env->GetStringChars(sendctrlcExePath, NULL);
+  return SendCtrlC(pid, exePath);
 }
 
 JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_setPriority(JNIEnv* env, jclass clazz, jint pid, jint priority) {

--- a/native/java-interface.h
+++ b/native/java-interface.h
@@ -17,6 +17,14 @@ JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_kill
 
 /*
  * Class:     org_jvnet_winp_Native
+ * Method:    sendCtrlC
+ * Signature: (I)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_sendCtrlC
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     org_jvnet_winp_Native
  * Method:    isCriticalProcess
  * Signature: (I)Z
  */

--- a/native/java-interface.h
+++ b/native/java-interface.h
@@ -18,10 +18,10 @@ JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_kill
 /*
  * Class:     org_jvnet_winp_Native
  * Method:    sendCtrlC
- * Signature: (I)Z
+ * Signature: (ILjava/lang/String)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_sendCtrlC
-  (JNIEnv *, jclass, jint);
+  (JNIEnv *, jclass, jint, jstring);
 
 /*
  * Class:     org_jvnet_winp_Native

--- a/native/runtime.cpp
+++ b/native/runtime.cpp
@@ -13,22 +13,6 @@ BOOL WINAPI DllMain(HANDLE hInst, ULONG dwReason, LPVOID lpReserved) {
 	return TRUE;
 }
 
-extern "C" __declspec(dllexport) void CALLBACK SendCtrlCMain(HWND hwnd, HINSTANCE hinst, LPCSTR pszCmdLine, int nCmdShow) {
-  int pid = -1;
-  int count = sscanf_s(pszCmdLine, "%i", &pid);
-  if (count != 1) {
-    return;
-  }
-
-  FreeConsole();
-  if (!AttachConsole(pid)) {
-    return;
-  }
-
-  SetConsoleCtrlHandler(NULL, TRUE);
-  GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0);
-}
-
 std::wstring GetDllFilename() {
   std::vector<wchar_t> pathBuf;
   DWORD copied = 0;

--- a/native/runtime.cpp
+++ b/native/runtime.cpp
@@ -13,18 +13,6 @@ BOOL WINAPI DllMain(HANDLE hInst, ULONG dwReason, LPVOID lpReserved) {
 	return TRUE;
 }
 
-std::wstring GetDllFilename() {
-  std::vector<wchar_t> pathBuf;
-  DWORD copied = 0;
-  do {
-    pathBuf.resize(pathBuf.size() + MAX_PATH);
-    copied = GetModuleFileNameW(static_cast<HMODULE>(hDllInst), &pathBuf[0], static_cast<DWORD>(pathBuf.size()));
-  }
-  while (copied >= pathBuf.size());
-
-  return std::wstring(pathBuf.begin(), pathBuf.begin() + copied);
-}
-
 void error( JNIEnv* env, const char* file, int line, const char* msg ) {
 	DWORD errorCode = GetLastError();
 

--- a/native/runtime.cpp
+++ b/native/runtime.cpp
@@ -1,13 +1,44 @@
 #include "stdafx.h"
 #include "winp.h"
+#include <vector>
 
+HANDLE              hDllInst;
 LPFN_ISWOW64PROCESS fnIsWow64Process;
 
 extern "C"
 BOOL WINAPI DllMain(HANDLE hInst, ULONG dwReason, LPVOID lpReserved) {
+	hDllInst = hInst;
 	fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(
 		GetModuleHandle(TEXT("kernel32")), "IsWow64Process");
 	return TRUE;
+}
+
+extern "C" __declspec(dllexport) void CALLBACK SendCtrlCMain(HWND hwnd, HINSTANCE hinst, LPCSTR pszCmdLine, int nCmdShow) {
+  int pid = -1;
+  int count = sscanf_s(pszCmdLine, "%i", &pid);
+  if (count != 1) {
+    return;
+  }
+
+  FreeConsole();
+  if (!AttachConsole(pid)) {
+    return;
+  }
+
+  SetConsoleCtrlHandler(NULL, TRUE);
+  GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0);
+}
+
+std::wstring GetDllFilename() {
+  std::vector<wchar_t> pathBuf;
+  DWORD copied = 0;
+  do {
+    pathBuf.resize(pathBuf.size() + MAX_PATH);
+    copied = GetModuleFileNameW(static_cast<HMODULE>(hDllInst), &pathBuf[0], static_cast<DWORD>(pathBuf.size()));
+  }
+  while (copied >= pathBuf.size());
+
+  return std::wstring(pathBuf.begin(), pathBuf.begin() + copied);
 }
 
 void error( JNIEnv* env, const char* file, int line, const char* msg ) {

--- a/native/sendctrlc/main.cpp
+++ b/native/sendctrlc/main.cpp
@@ -1,0 +1,24 @@
+
+#define STRICT
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <cstdlib>
+#include <cstring>
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    return 2;
+  }
+
+  int  pid = atoi(argv[1]);
+
+  FreeConsole();
+  if (!AttachConsole(pid)) {
+    return 1;
+  }
+
+  SetConsoleCtrlHandler(NULL, TRUE);
+  GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0);
+  return 0;
+}

--- a/native/sendctrlc/sendctrlc.vcxproj
+++ b/native/sendctrlc/sendctrlc.vcxproj
@@ -1,0 +1,160 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>sendctrlc32</RootNamespace>
+    <ProjectName>sendctrlc</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(MSBuildProjectDirectory)\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(MSBuildProjectDirectory)\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(MSBuildProjectDirectory)\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(MSBuildProjectDirectory)\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/native/stdafx.h
+++ b/native/stdafx.h
@@ -9,7 +9,6 @@
 #include <tchar.h>
 #include <tlhelp32.h>
 #include <jni.h>
-#include <string>
 #include <psapi.h>
 #pragma comment(lib, "psapi.lib")
 // if you don't have ntdll.lib, download Windows DDK

--- a/native/stdafx.h
+++ b/native/stdafx.h
@@ -9,6 +9,7 @@
 #include <tchar.h>
 #include <tlhelp32.h>
 #include <jni.h>
+#include <string>
 #include <psapi.h>
 #pragma comment(lib, "psapi.lib")
 // if you don't have ntdll.lib, download Windows DDK

--- a/native/winp.cpp
+++ b/native/winp.cpp
@@ -5,6 +5,41 @@
 #include "winp.h"
 #include "auto_handle.h"
 #include "java-interface.h"
+#include <vector>
+#include <iostream>
+//---------------------------------------------------------------------------
+// SendCtrlC
+//
+//  Sends CTRL+C to the specified process.
+//
+//  Parameters:
+//	  dwProcessId - identifier of the process to terminate
+//
+//  Returns:
+//	  TRUE, if successful, FALSE - otherwise.
+//
+BOOL WINAPI SendCtrlC(IN DWORD dwProcessId) {
+  STARTUPINFO         si;
+  PROCESS_INFORMATION pi;
+  ZeroMemory(&si, sizeof(si));
+  si.cb = sizeof(si);
+  ZeroMemory(&pi, sizeof(pi));
+
+  std::wstring cmd = L"rundll32.exe " + GetDllFilename() + L",SendCtrlCMain " +
+                     std::to_wstring(dwProcessId);
+  std::vector<wchar_t> cmd_buffer(cmd.begin(), cmd.end()); // with C++17, could just use cmd.data()
+
+  BOOL started = CreateProcessW(NULL, &cmd_buffer[0], NULL, NULL,
+                                FALSE, 0, NULL, NULL, &si, &pi);
+  if (started) {
+    // wait for termination if the process started
+    WaitForSingleObject(pi.hProcess, INFINITE);
+  }
+  CloseHandle(pi.hProcess);
+  CloseHandle(pi.hThread);
+
+  return started;
+}
 
 //---------------------------------------------------------------------------
 // KillProcess

--- a/native/winp.cpp
+++ b/native/winp.cpp
@@ -5,6 +5,8 @@
 #include "winp.h"
 #include "auto_handle.h"
 #include "java-interface.h"
+
+#include <string>
 #include <vector>
 
 //---------------------------------------------------------------------------

--- a/native/winp.h
+++ b/native/winp.h
@@ -6,6 +6,10 @@
 #define reportError(env,msg)	error(env,__FILE__,__LINE__,msg);
 void error(JNIEnv* env, const char* file, int line, const char* msg);
 
+std::wstring GetDllFilename();
+
+BOOL WINAPI SendCtrlC(IN DWORD dwProcessId);
+
 //
 // Kernel32.dll
 //

--- a/native/winp.h
+++ b/native/winp.h
@@ -8,7 +8,7 @@ void error(JNIEnv* env, const char* file, int line, const char* msg);
 
 std::wstring GetDllFilename();
 
-BOOL WINAPI SendCtrlC(IN DWORD dwProcessId);
+BOOL WINAPI SendCtrlC(IN DWORD dwProcessId, const wchar_t* pExePath);
 
 //
 // Kernel32.dll
@@ -62,7 +62,7 @@ enum MBI_REGION_TYPE : DWORD {
 	Private = MEM_PRIVATE
 };
 
-extern "C" NTSTATUS NTAPI ZwQueryInformationProcess(HANDLE hProcess, PROCESSINFOCLASS infoType, /*out*/ PVOID pBuf, /*sizeof pBuf*/ ULONG lenBuf, SIZE_T* /*PULONG*/ returnLength); 
+extern "C" NTSTATUS NTAPI ZwQueryInformationProcess(HANDLE hProcess, PROCESSINFOCLASS infoType, /*out*/ PVOID pBuf, /*sizeof pBuf*/ ULONG lenBuf, SIZE_T* /*PULONG*/ returnLength);
 
 
 #define	SystemProcessesAndThreadsInformation 5

--- a/native/winp.h
+++ b/native/winp.h
@@ -6,8 +6,6 @@
 #define reportError(env,msg)	error(env,__FILE__,__LINE__,msg);
 void error(JNIEnv* env, const char* file, int line, const char* msg);
 
-std::wstring GetDllFilename();
-
 BOOL WINAPI SendCtrlC(IN DWORD dwProcessId, const wchar_t* pExePath);
 
 //

--- a/native/winp.sln
+++ b/native/winp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "winp", "winp.vcxproj", "{6B623E61-2427-4C6A-B028-35E9A397AC3A}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sendctrlc", "sendctrlc\sendctrlc.vcxproj", "{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "native_test", "native_test", "{3F7718C9-97FF-4839-8197-63A69FAD6E54}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "testapp", "..\native_test\testapp\testapp.vcxproj", "{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93A1}"
@@ -25,6 +27,13 @@ Global
 		{6B623E61-2427-4C6A-B028-35E9A397AC3A}.Release|Win32.Build.0 = Release|Win32
 		{6B623E61-2427-4C6A-B028-35E9A397AC3A}.Release|x64.ActiveCfg = Release|x64
 		{6B623E61-2427-4C6A-B028-35E9A397AC3A}.Release|x64.Build.0 = Release|x64
+		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}.Debug|Win32.ActiveCfg = Debug|Win32
+		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}.Debug|Win32.Build.0 = Debug|Win32
+		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}.Debug|x64.ActiveCfg = Debug|Win32
+		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}.Release|Win32.ActiveCfg = Release|Win32
+		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}.Release|Win32.Build.0 = Release|Win32
+		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}.Release|x64.ActiveCfg = Release|x64
+		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93B1}.Release|x64.Build.0 = Release|x64
 		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93A1}.Debug|Win32.ActiveCfg = Debug|Win32
 		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93A1}.Debug|Win32.Build.0 = Debug|Win32
 		{AF1488B6-BF5B-4F3F-8AB7-5114D5BF93A1}.Debug|x64.ActiveCfg = Debug|Win32

--- a/src/main/java/org/jvnet/winp/Native.java
+++ b/src/main/java/org/jvnet/winp/Native.java
@@ -19,9 +19,10 @@ import java.util.logging.Logger;
 class Native {
 
     public static final String DLL_NAME = "64".equals(System.getProperty("sun.arch.data.model")) ? "winp.x64" : "winp";
+    public static final String CTRLCEXE_NAME = "64".equals(System.getProperty("sun.arch.data.model")) ? "sendctrlc.x64" : "sendctrlc";
 
     native static boolean kill(int pid, boolean recursive);
-    native static boolean sendCtrlC(int pid);
+    native static boolean sendCtrlC(int pid, String sendctrlcExePath);
     native static boolean isCriticalProcess(int pid);
     native static int setPriority(int pid, int value);
     native static int getProcessId(int handle);
@@ -67,8 +68,18 @@ class Native {
     private static final String DLL_TARGET = "winp.folder.preferred";
     private static final String UNPACK_DLL_TO_PARENT_DIR = "winp.unpack.dll.to.parent.dir";
 
+    private static String ctrlCExePath;
+
+    public static boolean sendCtrlC(int pid) {
+        if (ctrlCExePath == null) {
+            return false;
+        }
+        return sendCtrlC(pid, ctrlCExePath);
+    }
+
     static {
-        load();
+        File exeFile = load();
+        ctrlCExePath = (exeFile == null) ? null : exeFile.getPath();
     }
 
     private static String md5(URL res) {
@@ -91,16 +102,18 @@ class Native {
         }
     }
 
-    private static void load() {
+    private static File load() {
 
-        final URL res = Native.class.getClassLoader().getResource(DLL_NAME + ".dll");
+        final URL dllRes = Native.class.getClassLoader().getResource(DLL_NAME + ".dll");
 
         try {
-            if (res != null) {
-                loadByUrl(res);
+            if (dllRes != null) {
+                final URL exeRes = Native.class.getClassLoader().getResource(CTRLCEXE_NAME + ".exe");
+                return loadByUrl(dllRes, exeRes);
             } else {
                 // we don't know where winp.dll is, so let's just hope the user put it somewhere
                 System.loadLibrary(DLL_NAME);
+                return null;
             }
         } catch (Throwable cause) {
 
@@ -110,32 +123,40 @@ class Native {
         }
     }
 
-    private static void loadByUrl(URL res) throws IOException {
+    private static File loadByUrl(URL dllRes, URL exeRes) throws IOException {
 
-        String url = res.toExternalForm();
+        String dllUrl = dllRes.toExternalForm();
+        if (dllUrl.startsWith("file:")) {
+            // during debug the files are on disk and not in a jar
+            if (!exeRes.toExternalForm().startsWith("file:")) {
+                LOGGER.log(Level.WARNING, "DLL and EXE are inconsistenly present on disk");
+            }
 
-        if (url.startsWith("file:")) {
-            // during debug
             File f;
             try {
-                f = new File(res.toURI());
+                f = new File(dllRes.toURI());
             } catch (URISyntaxException e) {
-                f = new File(res.getPath());
+                f = new File(dllRes.getPath());
             }
             loadDll(f);
-            return;
+
+            File exeFile = new File(f.getParentFile(), CTRLCEXE_NAME + ".exe");
+            return exeFile;
         }
 
         try {
-            File dllFile = extractToStaticLocation(res);
+            File dllFile = extractToStaticLocation(dllRes);
+            File exeFile = extractExe(exeRes, dllFile.getParentFile());
             loadDll(dllFile);
-            return;
+            return exeFile;
         } catch (Throwable e) {
             LOGGER.log(Level.WARNING, "Failed to load DLL from static location", e);
         }
 
-        File dllFile = extractToTmpLocation(res);
+        File dllFile = extractToTmpLocation(dllRes);
+        File exeFile = extractExe(exeRes, dllFile.getParentFile());
         loadDll(dllFile);
+        return exeFile;
     }
 
     private static File extractToStaticLocation(URL url) throws IOException {
@@ -159,6 +180,14 @@ class Native {
         tmpFile.deleteOnExit();
         copyStream(res.openStream(), new FileOutputStream(tmpFile));
         return tmpFile;
+    }
+
+    private static File extractExe(URL res, File dir) throws IOException {
+        File destFile = new File(dir, CTRLCEXE_NAME + '.' + md5(res) + ".exe");
+        if (!destFile.exists()) {
+            copyStream(res.openStream(), new FileOutputStream(destFile));
+        }
+        return destFile;
     }
 
     private static File getJarFile(URL res) {

--- a/src/main/java/org/jvnet/winp/Native.java
+++ b/src/main/java/org/jvnet/winp/Native.java
@@ -21,6 +21,7 @@ class Native {
     public static final String DLL_NAME = "64".equals(System.getProperty("sun.arch.data.model")) ? "winp.x64" : "winp";
 
     native static boolean kill(int pid, boolean recursive);
+    native static boolean sendCtrlC(int pid);
     native static boolean isCriticalProcess(int pid);
     native static int setPriority(int pid, int value);
     native static int getProcessId(int handle);

--- a/src/main/java/org/jvnet/winp/WinProcess.java
+++ b/src/main/java/org/jvnet/winp/WinProcess.java
@@ -84,6 +84,15 @@ public class WinProcess {
         return Native.sendCtrlC(pid);
     }
 
+    public boolean isRunning() {
+        try {
+            Native.getCmdLine(pid);
+            return true;
+        } catch (WinpException e) {
+            return false;
+        }
+    }
+
     public boolean isCriticalProcess() {
         return Native.isCriticalProcess(pid);
     }

--- a/src/main/java/org/jvnet/winp/WinProcess.java
+++ b/src/main/java/org/jvnet/winp/WinProcess.java
@@ -78,6 +78,12 @@ public class WinProcess {
         Native.kill(pid,false);
     }
 
+    public boolean sendCtrlC() {
+        if (LOGGER.isLoggable(FINE))
+            LOGGER.fine(String.format("Attempting to send CTRL+C to pid=%d (%s)",pid,getCommandLine()));
+        return Native.sendCtrlC(pid);
+    }
+
     public boolean isCriticalProcess() {
         return Native.isCriticalProcess(pid);
     }

--- a/src/test/java/org/jvnet/winp/NativeAPITest.java
+++ b/src/test/java/org/jvnet/winp/NativeAPITest.java
@@ -121,15 +121,36 @@ public class NativeAPITest extends ProcessSpawningTest {
     }
 
     @Test
-    public void testSendCtrlC() throws Exception {
-        Process p = spawnProcess("cmd");
+    public void testPingAsDelay() throws Exception {
+        Process p = spawnProcess("PING", "-n", "10", "127.0.0.1"); // run for 10 secs
         
         WinProcess wp = new WinProcess(p);
-        Thread.sleep(100);
+        assertTrue(wp.isRunning());
         
-        wp.sendCtrlC();
-        Thread.sleep(4000);
+        Thread.sleep(4000); // just wait, don't send Ctrl+C
+
+        assertTrue(wp.isRunning());
+        wp.killRecursively();
+    }
+
+    @Test
+    public void testSendCtrlC() throws Exception {
+        Process p = spawnProcess("PING", "-n", "10", "127.0.0.1"); // run for 10 secs
         
+        WinProcess wp = new WinProcess(p);
+        assertTrue(wp.isRunning());
+        
+        // send Ctrl+C, then wait for a max of 4 secs
+        boolean sent = wp.sendCtrlC();
+        assertTrue(sent);
+        for (int i = 0; i < 40; ++i) {
+            if (!wp.isRunning()) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+
+        assertTrue(!wp.isRunning());
         wp.killRecursively();
     }
 

--- a/src/test/java/org/jvnet/winp/NativeAPITest.java
+++ b/src/test/java/org/jvnet/winp/NativeAPITest.java
@@ -119,7 +119,20 @@ public class NativeAPITest extends ProcessSpawningTest {
         Thread.sleep(100);
         wp.killRecursively();
     }
-    
+
+    @Test
+    public void testSendCtrlC() throws Exception {
+        Process p = spawnProcess("cmd");
+        
+        WinProcess wp = new WinProcess(p);
+        Thread.sleep(100);
+        
+        wp.sendCtrlC();
+        Thread.sleep(4000);
+        
+        wp.killRecursively();
+    }
+
     @Test
     public void shouldFailForNonExistentProcess() {
         int nonExistentPid = Integer.MAX_VALUE;


### PR DESCRIPTION
Hi! I'd like to discuss adding a sendCtrlC method to a WinProcess, which I'd need to address a defect in Jenkins (JENKINS-17116) in pull request https://github.com/jenkinsci/jenkins/pull/3414

Sending Ctrl+C is super awkward on Windows. Essentially we have to attach to the target's console, generate the Ctrl+C event, and detach again. That is only safe if we do it in a separate process that has only this purpose.

In the code below I am adding a function that can be called by rundll32 to winp.dll, which does exactly that.
There's a downside to this though: rundll32 is seen as suspicous by many anti-virus solutions, so the invocation might be blocked. What's even worse is that in this case rundll32 might show a message box that access was blocked, which is not acceptable.

The only solution is to not bake the Ctrl+C sending code into winp.dll, but into a separate exe.
**Can we ship that exe with the jar and make the DLL call it?** The DLL manages to find itself in the filesystem, so if our new exe was placed next to it, we could determine its path as well.

Thanks for taking a look!