### PR TITLE
Improve diagnostics and error propagation of CtrlC commands

### DIFF
--- a/native/java-interface.cpp
+++ b/native/java-interface.cpp
@@ -9,7 +9,7 @@ JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_kill(JNIEnv* env, jclass c
 
 JNIEXPORT jboolean JNICALL Java_org_jvnet_winp_Native_sendCtrlC(JNIEnv* env, jclass clazz, jint pid, jstring sendctrlcExePath) {
   const wchar_t* exePath = (wchar_t*)env->GetStringChars(sendctrlcExePath, NULL);
-  return SendCtrlC(pid, exePath);
+  return SendCtrlC(env, clazz, pid, exePath);
 }
 
 JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_setPriority(JNIEnv* env, jclass clazz, jint pid, jint priority) {

--- a/native/sendctrlc/main.cpp
+++ b/native/sendctrlc/main.cpp
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
 
   FreeConsole();
   if (!AttachConsole(pid)) {
-    return 1;
+    return GetLastError();
   }
 
   SetConsoleCtrlHandler(NULL, TRUE);

--- a/native/winp.cpp
+++ b/native/winp.cpp
@@ -9,6 +9,10 @@
 #include <string>
 #include <vector>
 
+// Max size of error messages in the methods. Defines static buffer sizes
+// This file uses a long buffer, because it prints executable paths in some cases.
+#define ERRMSG_SIZE 512
+
 //---------------------------------------------------------------------------
 // SendCtrlC
 //
@@ -19,8 +23,10 @@
 //
 //  Returns:
 //	  TRUE, if successful, FALSE - otherwise.
+//    When used from JNI, exceptions may be thrown instead
 //
-BOOL WINAPI SendCtrlC(IN DWORD dwProcessId, const wchar_t* pExePath) {
+BOOL WINAPI SendCtrlC(JNIEnv* pEnv, jclass clazz, IN DWORD dwProcessId, const wchar_t* pExePath) {
+  char errorBuffer[ERRMSG_SIZE];
   STARTUPINFO         si;
   PROCESS_INFORMATION pi;
   ZeroMemory(&si, sizeof(si));
@@ -37,13 +43,25 @@ BOOL WINAPI SendCtrlC(IN DWORD dwProcessId, const wchar_t* pExePath) {
   BOOL success = FALSE;
   if (started) {
     // wait for termination if the process started, max. 5 secs
-    WaitForSingleObject(pi.hProcess, 5000);
+    DWORD ret = WaitForSingleObject(pi.hProcess, 5000);
+    if (ret != WAIT_OBJECT_0) {
+        sprintf_s<ERRMSG_SIZE>(errorBuffer, "Failed to send Ctrl+C to process with pid=%d. WaitForSingleObject exit code: %d (last error: d).", dwProcessId, ret, GetLastError());
+        reportError(pEnv, errorBuffer);
+    }
 
     // then set success flag if the exit code was 0
     DWORD exit_code;
     if (GetExitCodeProcess(pi.hProcess, &exit_code) != FALSE) {
       success = (exit_code == 0);
+      if (exit_code != 0) {
+        sprintf_s<ERRMSG_SIZE>(errorBuffer, "External Ctrl+C execution failed for process pid=%d. Ctrl+C process exited with code %d: %s.", dwProcessId, exit_code,
+            (exit_code == -1) ? "Wrong arguments" : "Failed to attach to the console (see the AttachConsole WinAPI call)");
+        reportError(pEnv, errorBuffer);
+      }
     }
+  } else {
+    sprintf_s<ERRMSG_SIZE>(errorBuffer, "Failed to send Ctrl+C to process with pid=%d. Signal process did not start: %s.", dwProcessId, cmd);
+    reportError(pEnv, errorBuffer);
   }
 
   CloseHandle(pi.hProcess);

--- a/native/winp.h
+++ b/native/winp.h
@@ -6,7 +6,7 @@
 #define reportError(env,msg)	error(env,__FILE__,__LINE__,msg);
 void error(JNIEnv* env, const char* file, int line, const char* msg);
 
-BOOL WINAPI SendCtrlC(IN DWORD dwProcessId, const wchar_t* pExePath);
+BOOL WINAPI SendCtrlC(JNIEnv* pEnv, jclass clazz, IN DWORD dwProcessId, const wchar_t* pExePath);
 
 //
 // Kernel32.dll

--- a/src/main/java/org/jvnet/winp/Native.java
+++ b/src/main/java/org/jvnet/winp/Native.java
@@ -1,6 +1,8 @@
 package org.jvnet.winp;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.annotation.CheckReturnValue;
 import java.math.BigInteger;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -70,8 +72,18 @@ class Native {
 
     private static String ctrlCExePath;
 
-    public static boolean sendCtrlC(int pid) {
+    /**
+     * Sends Ctrl+C to the process.
+     * Due to the Windows platform specifics, this execution will spawn a separate thread to deliver the signal.
+     * This process is expected to be executed within a 5-second timeout.
+     * @param pid PID to receive the signal
+     * @return {@code true} if the signal was delivered successfully
+     * @throws WinpException Execution error
+     */
+    @CheckReturnValue
+    public static boolean sendCtrlC(int pid) throws WinpException {
         if (ctrlCExePath == null) {
+            LOGGER.log(Level.WARNING, "Cannot send the CtrlC signal to the process. Cannot find the executable {0}.dll", CTRLCEXE_NAME);
             return false;
         }
         return sendCtrlC(pid, ctrlCExePath);

--- a/src/main/java/org/jvnet/winp/WinProcess.java
+++ b/src/main/java/org/jvnet/winp/WinProcess.java
@@ -1,5 +1,6 @@
 package org.jvnet.winp;
 
+import javax.annotation.CheckReturnValue;
 import java.lang.reflect.Field;
 import java.util.Comparator;
 import java.util.TreeMap;
@@ -78,7 +79,15 @@ public class WinProcess {
         Native.kill(pid,false);
     }
 
-    public boolean sendCtrlC() {
+    /**
+     * Sends Ctrl+C to the process.
+     * Due to the Windows platform specifics, this execution will spawn a separate thread to deliver the signal.
+     * This process is expected to be executed within a 5-second timeout.
+     * @return {@code true} if the signal was delivered successfully
+     * @throws WinpException Execution error
+     */
+    @CheckReturnValue
+    public boolean sendCtrlC() throws WinpException {
         if (LOGGER.isLoggable(FINE))
             LOGGER.fine(String.format("Attempting to send CTRL+C to pid=%d (%s)",pid,getCommandLine()));
         return Native.sendCtrlC(pid);

--- a/src/test/java/org/jvnet/winp/NativeAPITest.java
+++ b/src/test/java/org/jvnet/winp/NativeAPITest.java
@@ -135,14 +135,14 @@ public class NativeAPITest extends ProcessSpawningTest {
 
     @Test
     public void testSendCtrlC() throws Exception {
-        Process p = spawnProcess("PING", "-n", "10", "127.0.0.1"); // run for 10 secs
+        Process p = spawnProcess("PING", "-n", "20", "127.0.0.1"); // run for 20 secs
         
         WinProcess wp = new WinProcess(p);
-        assertTrue(wp.isRunning());
+        assertTrue("Process is not running: " + p, wp.isRunning());
         
         // send Ctrl+C, then wait for a max of 4 secs
         boolean sent = wp.sendCtrlC();
-        assertTrue(sent);
+        assertTrue("Failed to send the Ctrl+C signal to the process: " + p, sent);
         for (int i = 0; i < 40; ++i) {
             if (!wp.isRunning()) {
                 break;
@@ -150,8 +150,17 @@ public class NativeAPITest extends ProcessSpawningTest {
             Thread.sleep(100);
         }
 
-        assertTrue(!wp.isRunning());
+        assertTrue("Process has not been terminated after Ctrl+C", !wp.isRunning());
         wp.killRecursively();
+    }
+
+    @Test(expected = WinpException.class)
+    public void testSendCtrlC_nonExistentPID() throws Exception {
+        WinProcess wp = new WinProcess(Integer.MAX_VALUE);
+        assertFalse("Process is running when it should not: " + wp, wp.isRunning());
+
+        // send Ctrl+C, then wait for a max of 4 secs
+        boolean sent = wp.sendCtrlC();
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #49 from @stephanreiter

When I was testing the change on my laptop before the release (Windows 10 64bit latest on MacBook Pro 2014), I have got the flaky test issue. So I have improved diagnostics and error propagation to understand what's going on:

Example of the new error:

```
testSendCtrlC_nonExistentPID(org.jvnet.winp.NativeAPITest)  Time elapsed: 0.001 sec  <<< ERROR!
org.jvnet.winp.WinpException: External Ctrl+C execution failed for process pid=2147483647. Ctrl+C process exited with code 87: Failed to attach to the console (see the AttachConsole WinAPI call). error=0 at winp.cpp:59
        at org.jvnet.winp.Native.sendCtrlC(Native Method)
        at org.jvnet.winp.Native.sendCtrlC(Native.java:89)
        at org.jvnet.winp.WinProcess.sendCtrlC(WinProcess.java:93)
        at org.jvnet.winp.NativeAPITest.testSendCtrlC_nonExistentPID(NativeAPITest.java:163)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
```

Due to whatever reason the process sometimes does not exist by the time the console attached to it. It does not seem to be a process completion, because the timeout didn't happen so far. The issue also happens only during `build.cmd cleanbuild`, but not during Unit test runs from IDE. After raising the timeouts and adding diagnostics the issue happens almost every time. 

@stephanreiter I would appreciate your feedback. I still can release alpha with a broken test if needed, but I want to have this diagnostics in place at least
