### PR TITLE
Use jlong for HANDLE and GetProcessId instead of Nt kernel private fu…

### DIFF
--- a/native/envvar-cmdline.cpp
+++ b/native/envvar-cmdline.cpp
@@ -312,22 +312,14 @@ jstring getCmdLineAndEnvVars(
 	return packedStr;
 }
 
-JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_getProcessId(JNIEnv* pEnv, jclass clazz, jint handle) {
+JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_getProcessId(JNIEnv* pEnv, jclass clazz, jlong handle) {
+	char errorBuffer[ERRMSG_SIZE];
 	HANDLE hProcess = (HANDLE)handle;
-	PROCESS_BASIC_INFORMATION ProcInfo;
-	SIZE_T sRead;
-	if(!NT_SUCCESS(ZwQueryInformationProcess(hProcess, ProcessBasicInformation, &ProcInfo, sizeof(ProcInfo), &sRead))) {
-		reportError(pEnv,"Failed to ZWQueryInformationProcess");
+	DWORD pid = GetProcessId(hProcess);
+	if (!pid) {
+		sprintf_s<ERRMSG_SIZE>(errorBuffer, "Failed to get process id from handle=%ld.", handle);
+		reportError(pEnv, errorBuffer);
 		return -1;
 	}
-	
-	return (jint)ProcInfo.UniqueProcessId;
-/*	ULONG id=0;
-
-	if(!ReadProcessMemory(hProcess, ProcInfo.UniqueProcessId, &id, sizeof(ULONG), &_)) {
-		reportError(pEnv,"Failed to read process ID");
-		return NULL;
-	}
-
-	return id;*/
+	return pid;
 }

--- a/native/java-interface.h
+++ b/native/java-interface.h
@@ -42,10 +42,10 @@ JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_setPriority
 /*
  * Class:     org_jvnet_winp_Native
  * Method:    getProcessId
- * Signature: (I)I
+ * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_org_jvnet_winp_Native_getProcessId
-  (JNIEnv *, jclass, jint);
+  (JNIEnv *, jclass, jlong);
 
 /*
  * Class:     org_jvnet_winp_Native

--- a/native/stdafx.h
+++ b/native/stdafx.h
@@ -3,7 +3,7 @@
 // are changed infrequently
 #pragma once
 
-#define _WIN32_WINNT 0x500
+#define _WIN32_WINNT 0x501
 
 #include <windows.h>
 #include <tchar.h>

--- a/src/main/java/org/jvnet/winp/Native.java
+++ b/src/main/java/org/jvnet/winp/Native.java
@@ -25,7 +25,7 @@ class Native {
     native static boolean sendCtrlC(int pid, String sendctrlcExePath);
     native static boolean isCriticalProcess(int pid);
     native static int setPriority(int pid, int value);
-    native static int getProcessId(int handle);
+    native static int getProcessId(long handle);
     native static boolean exitWindowsEx(int flags,int reasonCode);
 
     /**

--- a/src/main/java/org/jvnet/winp/WinProcess.java
+++ b/src/main/java/org/jvnet/winp/WinProcess.java
@@ -41,7 +41,7 @@ public class WinProcess {
         try {
             Field f = proc.getClass().getDeclaredField("handle");
             f.setAccessible(true);
-            int handle = ((Number)f.get(proc)).intValue();
+            long handle = f.getLong(proc);
             pid = Native.getProcessId(handle);
         } catch (NoSuchFieldException e) {
             throw new NotWindowsException(e);


### PR DESCRIPTION
…nction

HANDLE is a typedef for a void*. On Win64 we cannot safely wrap that in a 32-bit int, so switch to 64-bit long. The hope is that this fixes random test failures that occur more when the system had been under load recently (and therefore has more open/recently closed handles).