### PR TITLE
Update WinProcess.java

### DIFF
--- a/src/main/java/org/jvnet/winp/WinProcess.java
+++ b/src/main/java/org/jvnet/winp/WinProcess.java
@@ -53,7 +53,11 @@ public class WinProcess {
 
     @Override
     public String toString() {
-        return "WinProcess pid#" + pid + ", command line: " +  (commandline != null ? commandline : "not ready");
+        return String.format("WinProcess pid# %d", pid);
+    }
+    
+    public String toStringDetailed() {
+        return String.format("%s - command line: %s", toString(), getCommandLine());
     }
     
     /**


### PR DESCRIPTION
Created a detailed toString function to augment the default toString - ensuring the regular `toString()` function is not performing parsing tasks and gives the user the basic PID information only. 

If the user desires a detailed toString, they can use `toStringDetailed()`

Feel free to pick this apart or change my strategy. I'm not sure if the `String.format` function also is slower than using the `".." + ".."` style of string concatenation which is employed now in the code. I just find the printf style to be more readable.