### PR TITLE
Change Windows agent version from 2019 to 2022

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@
 buildPlugin(useContainerAgent: false, configurations: [
   // TODO: switch to 2022 or 2025
   // 2019 agents won't be available for long cf https://github.com/jenkins-infra/helpdesk/issues/4954
-  [platform: 'windows-2019', jdk: 25],
-  [platform: 'windows-2019', jdk: 21]
+  [platform: 'windows-2022', jdk: 25],
+  [platform: 'windows-2022', jdk: 21]
 ])
 


### PR DESCRIPTION
Updated Jenkinsfile to use Windows 2022 agents.

<!-- Please describe your pull request here. -->
The `winp` builds started failing on Windows agents because `msbuild` was no longer available (`vswhere.exe` could not find it). This was due to jenkins-infra making changes to drop `windows-2019` agents, where `vs-build-tools` was previously installed exclusively. Support for `vs-build-tools` was recently added to modern Windows agents via jenkins-infra/packer-images#2483.

This PR updates the Jenkinsfile `configurations` block to migrate off the deprecated `windows-2019` platform and use `windows-2022` instead, resolving the missing MSBuild issue and restoring the Windows CI builds.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
- Confirmed the Jenkins infra issues regarding MSBuild availability on Windows 2022.
- The success of this PR's own automated Jenkins CI build will serve as the validation that the `winp` build successfully compiles using `msbuild` on the new `windows-2022` agent.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
  - Resolves jenkins-infra/helpdesk/#5040
  - Resolves jenkinsci/winp/#161
- [x] Link to relevant pull requests, esp. upstream and downstream changes
  - Relates to jenkins-infra/packer-images/#2483
  - Relates to jenkins-infra/helpdesk/#4954
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
